### PR TITLE
Feat: 질문 관련 엔티티 세팅

### DIFF
--- a/src/main/java/com/coredisc/domain/Category.java
+++ b/src/main/java/com/coredisc/domain/Category.java
@@ -17,10 +17,4 @@ public class Category extends BaseEntity {
 
     @Column(nullable = false)
     private String name;
-
-
-    // TODO: 연관관계 설정, 엔티티 정의하고 todo 제거해주세요.
-    // - @ManyToOne Member
-    // - @OneToMany PersonalQuestion
-    // - @OneToMany OfficialQuestion
 }

--- a/src/main/java/com/coredisc/domain/OfficialQuestion.java
+++ b/src/main/java/com/coredisc/domain/OfficialQuestion.java
@@ -1,8 +1,13 @@
 package com.coredisc.domain;
 
 import com.coredisc.domain.common.BaseEntity;
+import com.coredisc.domain.mapping.QuestionCategory;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -15,8 +20,20 @@ public class OfficialQuestion extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // TODO: 연관관계 설정, 엔티티 정의하고 todo 제거해주세요.
-    // - @ManyToOne Member
-    // - @ManyToOne Category
-    // - @OneToMany TodayQuestion
+    @ColumnDefault("1")     // 0: 기본질문, 1: 공유질문
+    @Column(nullable = false)
+    private boolean isOfficial;
+
+    @Column(nullable = false)
+    private String contents;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "officialQuestion")
+    private List<QuestionCategory> questionCategoryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "officialQuestion")
+    private List<TodayQuestion> todayQuestionList = new ArrayList<>();
 }

--- a/src/main/java/com/coredisc/domain/PersonalQuestion.java
+++ b/src/main/java/com/coredisc/domain/PersonalQuestion.java
@@ -1,8 +1,12 @@
 package com.coredisc.domain;
 
 import com.coredisc.domain.common.BaseEntity;
+import com.coredisc.domain.mapping.QuestionCategory;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -18,7 +22,13 @@ public class PersonalQuestion extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
-    // TODO: 연관관계 설정, 엔티티 정의하고 todo 제거해주세요.
-    // - @ManyToOne Category
-    // - @OneToMany TodayQuestion
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "personalQuestion")
+    private List<QuestionCategory> questionCategoryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "personalQuestion")
+    private List<TodayQuestion> todayQuestionList = new ArrayList<>();
 }

--- a/src/main/java/com/coredisc/domain/TodayQuestion.java
+++ b/src/main/java/com/coredisc/domain/TodayQuestion.java
@@ -1,10 +1,12 @@
 package com.coredisc.domain;
 
 import com.coredisc.domain.common.BaseEntity;
+import com.coredisc.domain.common.enums.QuestionType;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -17,9 +19,22 @@ public class TodayQuestion extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
+    protected LocalDateTime selectedDate;
 
-    // TODO: 연관관계 설정, 엔티티 정의하고 todo 제거해주세요.
-    // - @ManyToOne Member
-    // - @ManyToOne PersonalQuestion
-    // - @ManyToOne OfficialQuestion
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private QuestionType questionType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "official_question_id")
+    private OfficialQuestion officialQuestion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "personal_question_id")
+    private PersonalQuestion personalQuestion;
 }

--- a/src/main/java/com/coredisc/domain/common/enums/QuestionType.java
+++ b/src/main/java/com/coredisc/domain/common/enums/QuestionType.java
@@ -1,0 +1,5 @@
+package com.coredisc.domain.common.enums;
+
+public enum QuestionType {
+    FIXED,RANDOM
+}

--- a/src/main/java/com/coredisc/domain/mapping/QuestionCategory.java
+++ b/src/main/java/com/coredisc/domain/mapping/QuestionCategory.java
@@ -1,0 +1,35 @@
+package com.coredisc.domain.mapping;
+
+import com.coredisc.domain.Category;
+import com.coredisc.domain.OfficialQuestion;
+import com.coredisc.domain.PersonalQuestion;
+import com.coredisc.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class QuestionCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "official_question_id")
+    private OfficialQuestion officialQuestion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "personal_question_id")
+    private PersonalQuestion personalQuestion;
+}


### PR DESCRIPTION
## 💡 작업 내용 요약
어떤 기능/버그/리팩토링을 했는지 요약해주세요.

- 질문 카테고리 엔티티 설정 (Category)
- 선택한 질문 카테고리 엔티티 설정 (QuestionCategory)
   - 카테고리 복수 선택 가능해짐에 따라 매핑 엔티티를 만들었습니다. 
- 발행 질문 엔티티 설정 (OfficialQuestion)
- 저장 질문 엔티티 설정 (PersonalQuestion)
- 선택한 질문 엔티티 설정 (TodayQuestion)
   - 고정&랜덤 여부를 ENUM 타입으로 뺏습니다. (QuestionType)
   
## ✅ 체크리스트
- [ ] 로컬에서 정상 동작을 확인했는가?
- [ ] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #7 

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
커밋 내용 중 'Feat: 발행질문 Enum 타입 추가'으로 잘못 작성한 것이 있는데 'Feat: 선택한 질문 Enum 타입 추가'입니다. 다음부턴 더 주의하겠습니다. 