### PR TITLE
Feat: 팔로우 관련 API 구현

### DIFF
--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandService.java
@@ -7,4 +7,6 @@ public interface FollowCommandService {
     // 팔로우 하기
     Follow follow(Long followerId, Long followingId);
 
+    // 언팔로우 하기
+    void unfollow(Long followerId, Long followingId);
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandService.java
@@ -1,0 +1,10 @@
+package com.coredisc.application.service.follow;
+
+import com.coredisc.domain.follow.Follow;
+
+public interface FollowCommandService {
+
+    // 팔로우 하기
+    Follow follow(Long followerId, Long followingId);
+
+}

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandService.java
@@ -5,8 +5,8 @@ import com.coredisc.domain.follow.Follow;
 public interface FollowCommandService {
 
     // 팔로우 하기
-    Follow follow(Long followerId, Long followingId);
+    Follow follow(Long memberId, Long targetId);
 
     // 언팔로우 하기
-    void unfollow(Long followerId, Long followingId);
+    void unfollow(Long memberId, Long targetId);
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandService.java
@@ -1,12 +1,13 @@
 package com.coredisc.application.service.follow;
 
 import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.member.Member;
 
 public interface FollowCommandService {
 
     // 팔로우 하기
-    Follow follow(Long memberId, Long targetId);
+    Follow follow(Member member, Long targetId);
 
     // 언팔로우 하기
-    void unfollow(Long memberId, Long targetId);
+    void unfollow(Member member, Long targetId);
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
@@ -42,4 +42,27 @@ public class FollowCommandServiceImpl implements FollowCommandService {
         return followRepository.save(follow);
     }
 
+    @Override
+    public void unfollow(Long followerId, Long followingId) {
+
+        if (followerId.equals(followingId)) {
+            throw new FollowHandler(ErrorStatus.SELF_UNFOLLOW_NOT_ALLOWED);
+        }
+
+        Member follower = memberRepository.findById(followerId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Member following = memberRepository.findById(followerId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 팔로우한 이력이 없을 경우
+        if (!followRepository.existsByFollowerAndFollowing(follower, following)){
+            throw new FollowHandler(ErrorStatus.FOLLOW_NOT_FOUND);
+        }
+
+        Follow follow = followRepository.findByFollowerAndFollowing(follower, following);
+
+        followRepository.delete(follow);
+    }
+
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
@@ -18,7 +18,6 @@ public class FollowCommandServiceImpl implements FollowCommandService {
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
 
-    //TODO: 반환 FollowResultDTO로 수정하기
     @Override
     public Follow follow(Long memberId, Long targetId) {
 

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
@@ -20,47 +20,47 @@ public class FollowCommandServiceImpl implements FollowCommandService {
 
     //TODO: 반환 FollowResultDTO로 수정하기
     @Override
-    public Follow follow(Long followerId, Long followingId) {
+    public Follow follow(Long memberId, Long targetId) {
 
-        if (followerId.equals(followingId)) {
+        if (memberId.equals(targetId)) {
             throw new FollowHandler(ErrorStatus.SELF_FOLLOW_NOT_ALLOWED);
         }
 
-        Member follower = memberRepository.findById(followerId)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        Member following = memberRepository.findById(followerId)
+        Member target = memberRepository.findById(targetId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 이미 팔로우한 이력이 있을 경우
-        if (followRepository.existsByFollowerAndFollowing(follower, following)){
+        if (followRepository.existsByFollowerAndFollowing(member, target)){
             throw new FollowHandler(ErrorStatus.ALREADY_FOLLOWING);
         }
 
-        Follow follow = FollowConverter.toFollow(follower, following);
+        Follow follow = FollowConverter.toFollow(member, target);
 
         return followRepository.save(follow);
     }
 
     @Override
-    public void unfollow(Long followerId, Long followingId) {
+    public void unfollow(Long memberId, Long targetId) {
 
-        if (followerId.equals(followingId)) {
+        if (memberId.equals(targetId)) {
             throw new FollowHandler(ErrorStatus.SELF_UNFOLLOW_NOT_ALLOWED);
         }
 
-        Member follower = memberRepository.findById(followerId)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        Member following = memberRepository.findById(followerId)
+        Member target = memberRepository.findById(targetId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 팔로우한 이력이 없을 경우
-        if (!followRepository.existsByFollowerAndFollowing(follower, following)){
+        if (!followRepository.existsByFollowerAndFollowing(member, target)){
             throw new FollowHandler(ErrorStatus.FOLLOW_NOT_FOUND);
         }
 
-        Follow follow = followRepository.findByFollowerAndFollowing(follower, following);
+        Follow follow = followRepository.findByFollowerAndFollowing(member, target);
 
         followRepository.delete(follow);
     }

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
@@ -19,14 +19,11 @@ public class FollowCommandServiceImpl implements FollowCommandService {
     private final FollowRepository followRepository;
 
     @Override
-    public Follow follow(Long memberId, Long targetId) {
+    public Follow follow(Member member, Long targetId) {
 
-        if (memberId.equals(targetId)) {
+        if (member.getId().equals(targetId)) {
             throw new FollowHandler(ErrorStatus.SELF_FOLLOW_NOT_ALLOWED);
         }
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         Member target = memberRepository.findById(targetId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
@@ -42,14 +39,11 @@ public class FollowCommandServiceImpl implements FollowCommandService {
     }
 
     @Override
-    public void unfollow(Long memberId, Long targetId) {
+    public void unfollow(Member member, Long targetId) {
 
-        if (memberId.equals(targetId)) {
+        if (member.getId().equals(targetId)) {
             throw new FollowHandler(ErrorStatus.SELF_UNFOLLOW_NOT_ALLOWED);
         }
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         Member target = memberRepository.findById(targetId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
@@ -1,0 +1,45 @@
+package com.coredisc.application.service.follow;
+
+import com.coredisc.common.apiPayload.status.ErrorStatus;
+import com.coredisc.common.converter.FollowConverter;
+import com.coredisc.common.exception.handler.FollowHandler;
+import com.coredisc.common.exception.handler.MemberHandler;
+import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.follow.FollowRepository;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FollowCommandServiceImpl implements FollowCommandService {
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    //TODO: 반환 FollowResultDTO로 수정하기
+    @Override
+    public Follow follow(Long followerId, Long followingId) {
+
+        if (followerId.equals(followingId)) {
+            throw new FollowHandler(ErrorStatus.SELF_FOLLOW_NOT_ALLOWED);
+        }
+
+        Member follower = memberRepository.findById(followerId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Member following = memberRepository.findById(followerId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 이미 팔로우한 이력이 있을 경우
+        if (followRepository.existsByFollowerAndFollowing(follower, following)){
+            throw new FollowHandler(ErrorStatus.ALREADY_FOLLOWING);
+        }
+
+        Follow follow = FollowConverter.toFollow(follower, following);
+
+        return followRepository.save(follow);
+    }
+
+}

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
@@ -8,11 +8,13 @@ import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.follow.FollowRepository;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.member.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class FollowCommandServiceImpl implements FollowCommandService {
 
     private final MemberRepository memberRepository;

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
@@ -1,14 +1,17 @@
 package com.coredisc.application.service.follow;
 
+import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
+
+import java.util.List;
 
 public interface FollowQueryService {
 
     // 팔로워 목록 조회
-    FollowResponseDTO.FollowerListViewDTO getFollowers(Member member);
+    List<Follow> getFollowers(Member member);
 
     // 팔로잉 목록 조회
-    FollowResponseDTO.FollowingListViewDTO getFollowings(Member member);
+    List<Follow> getFollowings(Member member);
 
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
@@ -1,13 +1,14 @@
 package com.coredisc.application.service.follow;
 
+import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 
 public interface FollowQueryService {
 
     // 팔로워 목록 조회
-    FollowResponseDTO.FollowerListViewDTO getFollowers(Long memberId);
+    FollowResponseDTO.FollowerListViewDTO getFollowers(Member member);
 
     // 팔로잉 목록 조회
-    FollowResponseDTO.FollowingListViewDTO getFollowings(Long memberId);
+    FollowResponseDTO.FollowingListViewDTO getFollowings(Member member);
 
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
@@ -8,6 +8,6 @@ public interface FollowQueryService {
     FollowResponseDTO.FollowerListViewDTO getFollowers(Long memberId);
 
     // 팔로잉 목록 조회
-
+    FollowResponseDTO.FollowingListViewDTO getFollowings(Long memberId);
 
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
@@ -1,0 +1,4 @@
+package com.coredisc.application.service.follow;
+
+public interface FollowQueryService {
+}

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
@@ -1,4 +1,13 @@
 package com.coredisc.application.service.follow;
 
+import com.coredisc.presentation.dto.follow.FollowResponseDTO;
+
 public interface FollowQueryService {
+
+    // 팔로워 목록 조회
+    FollowResponseDTO.FollowerListViewDTO getFollowers(Long memberId);
+
+    // 팔로잉 목록 조회
+
+
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
@@ -20,18 +20,14 @@ public class FollowQueryServiceImpl implements FollowQueryService {
     private final FollowRepository followRepository;
 
     @Override
-    public FollowResponseDTO.FollowerListViewDTO getFollowers(Member member) {
+    public List<Follow> getFollowers(Member member) {
 
-        List<Follow> followers = followRepository.findAllByFollowing(member);
-
-        return FollowConverter.toFollowerListViewDTO(followers);
+        return followRepository.findAllByFollowing(member);
     }
 
     @Override
-    public FollowResponseDTO.FollowingListViewDTO getFollowings(Member member) {
+    public List<Follow> getFollowings(Member member) {
 
-        List<Follow> followings = followRepository.findAllByFollower(member);
-
-        return FollowConverter.toFollowingListViewDTO(followings);
+        return followRepository.findAllByFollower(member);
     }
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
@@ -30,4 +30,15 @@ public class FollowQueryServiceImpl implements FollowQueryService {
 
         return FollowConverter.toFollowerListViewDTO(followers);
     }
+
+    @Override
+    public FollowResponseDTO.FollowingListViewDTO getFollowings(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        List<Follow> followings = followRepository.findAllByFollower(member);
+
+        return FollowConverter.toFollowingListViewDTO(followings);
+    }
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
@@ -1,4 +1,33 @@
 package com.coredisc.application.service.follow;
 
-public class FollowQueryServiceImpl {
+import com.coredisc.common.apiPayload.status.ErrorStatus;
+import com.coredisc.common.converter.FollowConverter;
+import com.coredisc.common.exception.handler.MemberHandler;
+import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.follow.FollowRepository;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.member.MemberRepository;
+import com.coredisc.presentation.dto.follow.FollowResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FollowQueryServiceImpl implements FollowQueryService {
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    @Override
+    public FollowResponseDTO.FollowerListViewDTO getFollowers(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        List<Follow> followers = followRepository.findAllByFollowing(member);
+
+        return FollowConverter.toFollowerListViewDTO(followers);
+    }
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
@@ -17,14 +17,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FollowQueryServiceImpl implements FollowQueryService {
 
-    private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
 
     @Override
-    public FollowResponseDTO.FollowerListViewDTO getFollowers(Long memberId) {
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    public FollowResponseDTO.FollowerListViewDTO getFollowers(Member member) {
 
         List<Follow> followers = followRepository.findAllByFollowing(member);
 
@@ -32,10 +28,7 @@ public class FollowQueryServiceImpl implements FollowQueryService {
     }
 
     @Override
-    public FollowResponseDTO.FollowingListViewDTO getFollowings(Long memberId) {
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    public FollowResponseDTO.FollowingListViewDTO getFollowings(Member member) {
 
         List<Follow> followings = followRepository.findAllByFollower(member);
 

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
@@ -1,0 +1,4 @@
+package com.coredisc.application.service.follow;
+
+public class FollowQueryServiceImpl {
+}

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -35,6 +35,7 @@ public enum ErrorStatus implements BaseErrorCode {
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW4001", "자기 자신은 팔로우할 수 없습니다."),
     ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "FOLLOW4002", "이미 팔로우한 이력이 있습니다."),
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW4003", "팔로우한 이력이 없습니다."),
+    SELF_UNFOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW4004", "자기 자신은 언팔로우할 수 없습니다."),
 
     // For test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트 용도");

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -28,6 +28,14 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "메일 발송 중 오류가 발생했습니다."),
     EMAIL_WRITE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5002", "메일 작성 중 문제가 발생했습니다."),
 
+    // Member 관련 에러
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "사용자를 찾을 수 없습니다."),
+
+    // Follow 관련 에러
+    SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW4001", "자기 자신은 팔로우할 수 없습니다."),
+    ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "FOLLOW4002", "이미 팔로우한 이력이 있습니다."),
+    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW4003", "팔로우한 이력이 없습니다."),
+
     // For test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트 용도");
 

--- a/src/main/java/com/coredisc/common/converter/FollowConverter.java
+++ b/src/main/java/com/coredisc/common/converter/FollowConverter.java
@@ -4,6 +4,7 @@ import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,6 +36,15 @@ public class FollowConverter {
 
         return FollowResponseDTO.FollowerListViewDTO.builder()
                 .followers(dtos)
+                .build();
+    }
+
+    public static FollowResponseDTO.FollowResultDTO toFollowResultDTO(Follow follow) {
+        return FollowResponseDTO.FollowResultDTO.builder()
+                .id(follow.getId())
+                .followerId(follow.getFollower().getId())
+                .followingId(follow.getFollowing().getId())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/com/coredisc/common/converter/FollowConverter.java
+++ b/src/main/java/com/coredisc/common/converter/FollowConverter.java
@@ -48,4 +48,21 @@ public class FollowConverter {
                 .build();
     }
 
+    public static FollowResponseDTO.FollowingDTO toFollowingDTO(Follow follow) {
+        return FollowResponseDTO.FollowingDTO.builder()
+                .followingId(follow.getFollowing().getId())
+                .followingNickname(follow.getFollowing().getNickname())
+                .followingUsername(follow.getFollowing().getUsername())
+                .build();
+    }
+
+    public static FollowResponseDTO.FollowingListViewDTO toFollowingListViewDTO(List<Follow> followings) {
+        List<FollowResponseDTO.FollowingDTO> dtos = followings.stream()
+                .map(FollowConverter::toFollowingDTO)
+                .collect(Collectors.toList());
+
+        return FollowResponseDTO.FollowingListViewDTO.builder()
+                .followings(dtos)
+                .build();
+    }
 }

--- a/src/main/java/com/coredisc/common/converter/FollowConverter.java
+++ b/src/main/java/com/coredisc/common/converter/FollowConverter.java
@@ -2,6 +2,10 @@ package com.coredisc.common.converter;
 
 import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.member.Member;
+import com.coredisc.presentation.dto.follow.FollowResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class FollowConverter {
 
@@ -15,5 +19,23 @@ public class FollowConverter {
                 .build();
     }
 
+    //TODO: profileImageUrl 추후 추가
+    public static FollowResponseDTO.FollowerDTO toFollowerDTO(Follow follow) {
+        return FollowResponseDTO.FollowerDTO.builder()
+                .followerId(follow.getFollower().getId())
+                .followerNickname(follow.getFollower().getNickname())
+                .followerUsername(follow.getFollower().getUsername())
+                .build();
+    }
+
+    public static FollowResponseDTO.FollowerListViewDTO toFollowerListViewDTO(List<Follow> follows) {
+        List<FollowResponseDTO.FollowerDTO> dtos = follows.stream()
+                .map(FollowConverter::toFollowerDTO)
+                .collect(Collectors.toList());
+
+        return FollowResponseDTO.FollowerListViewDTO.builder()
+                .followers(dtos)
+                .build();
+    }
 
 }

--- a/src/main/java/com/coredisc/common/converter/FollowConverter.java
+++ b/src/main/java/com/coredisc/common/converter/FollowConverter.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 
 public class FollowConverter {
 
-    //TODO : isCircle -> false 디폴트로 수정
     public static Follow toFollow(Member follower, Member following){
 
         return Follow.builder()

--- a/src/main/java/com/coredisc/common/converter/FollowConverter.java
+++ b/src/main/java/com/coredisc/common/converter/FollowConverter.java
@@ -1,0 +1,19 @@
+package com.coredisc.common.converter;
+
+import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.member.Member;
+
+public class FollowConverter {
+
+    //TODO : isCircle -> false 디폴트로 수정
+    public static Follow toFollow(Member follower, Member following){
+
+        return Follow.builder()
+                .follower(follower)
+                .following(following)
+                .isCircle(false)
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/coredisc/common/converter/FollowConverter.java
+++ b/src/main/java/com/coredisc/common/converter/FollowConverter.java
@@ -29,12 +29,13 @@ public class FollowConverter {
                 .build();
     }
 
-    public static FollowResponseDTO.FollowerListViewDTO toFollowerListViewDTO(List<Follow> follows) {
-        List<FollowResponseDTO.FollowerDTO> dtos = follows.stream()
+    public static FollowResponseDTO.FollowerListViewDTO toFollowerListViewDTO(List<Follow> followers) {
+        List<FollowResponseDTO.FollowerDTO> dtos = followers.stream()
                 .map(FollowConverter::toFollowerDTO)
                 .collect(Collectors.toList());
 
         return FollowResponseDTO.FollowerListViewDTO.builder()
+                .totalFollowerCount(followers.size())
                 .followers(dtos)
                 .build();
     }
@@ -62,6 +63,7 @@ public class FollowConverter {
                 .collect(Collectors.toList());
 
         return FollowResponseDTO.FollowingListViewDTO.builder()
+                .totalFollowingCount(followings.size())
                 .followings(dtos)
                 .build();
     }

--- a/src/main/java/com/coredisc/common/exception/handler/FollowHandler.java
+++ b/src/main/java/com/coredisc/common/exception/handler/FollowHandler.java
@@ -1,0 +1,10 @@
+package com.coredisc.common.exception.handler;
+
+import com.coredisc.common.apiPayload.code.BaseErrorCode;
+import com.coredisc.common.exception.GeneralException;
+
+public class FollowHandler extends GeneralException {
+    public FollowHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/coredisc/common/exception/handler/MemberHandler.java
+++ b/src/main/java/com/coredisc/common/exception/handler/MemberHandler.java
@@ -1,0 +1,10 @@
+package com.coredisc.common.exception.handler;
+
+import com.coredisc.common.apiPayload.code.BaseErrorCode;
+import com.coredisc.common.exception.GeneralException;
+
+public class MemberHandler extends GeneralException {
+    public MemberHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/coredisc/config/SecurityConfig.java
+++ b/src/main/java/com/coredisc/config/SecurityConfig.java
@@ -20,7 +20,8 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-resources/**",
             "/v3/api-docs/**",
-            "/api/auth/**"
+            "/api/auth/**",
+            "/api/followers/**"
     };
 
     @Bean

--- a/src/main/java/com/coredisc/config/SecurityConfig.java
+++ b/src/main/java/com/coredisc/config/SecurityConfig.java
@@ -20,10 +20,7 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-resources/**",
             "/v3/api-docs/**",
-            "/api/auth/**",
-            "/api/followers/**",
-            "/api/followings/**",
-            "/api/follow/**"
+            "/api/auth/**"
     };
 
     @Bean

--- a/src/main/java/com/coredisc/config/SecurityConfig.java
+++ b/src/main/java/com/coredisc/config/SecurityConfig.java
@@ -21,7 +21,9 @@ public class SecurityConfig {
             "/swagger-resources/**",
             "/v3/api-docs/**",
             "/api/auth/**",
-            "/api/followers/**"
+            "/api/followers/**",
+            "/api/followings/**",
+            "/api/follow/**"
     };
 
     @Bean

--- a/src/main/java/com/coredisc/domain/follow/Follow.java
+++ b/src/main/java/com/coredisc/domain/follow/Follow.java
@@ -1,4 +1,4 @@
-package com.coredisc.domain;
+package com.coredisc.domain.follow;
 
 import com.coredisc.domain.common.BaseEntity;
 import com.coredisc.domain.member.Member;

--- a/src/main/java/com/coredisc/domain/follow/Follow.java
+++ b/src/main/java/com/coredisc/domain/follow/Follow.java
@@ -27,6 +27,7 @@ public class Follow extends BaseEntity {
     private Member following;
 
     @Column(name = "is_circle", nullable = false)
-    private boolean isCircle;
+    @Builder.Default
+    private boolean isCircle = false;
 
 }

--- a/src/main/java/com/coredisc/domain/follow/FollowRepository.java
+++ b/src/main/java/com/coredisc/domain/follow/FollowRepository.java
@@ -2,10 +2,13 @@ package com.coredisc.domain.follow;
 
 import com.coredisc.domain.member.Member;
 
+import java.util.List;
+
 public interface FollowRepository {
 
     Follow save(Follow follow);
     boolean existsByFollowerAndFollowing(Member follower, Member following);
     Follow findByFollowerAndFollowing(Member follower, Member following);
     void delete(Follow follow);
+    List<Follow> findAllByFollowing(Member member);
 }

--- a/src/main/java/com/coredisc/domain/follow/FollowRepository.java
+++ b/src/main/java/com/coredisc/domain/follow/FollowRepository.java
@@ -1,0 +1,9 @@
+package com.coredisc.domain.follow;
+
+import com.coredisc.domain.member.Member;
+
+public interface FollowRepository {
+
+    Follow save(Follow follow);
+    boolean existsByFollowerAndFollowing(Member follower, Member following);
+}

--- a/src/main/java/com/coredisc/domain/follow/FollowRepository.java
+++ b/src/main/java/com/coredisc/domain/follow/FollowRepository.java
@@ -11,4 +11,5 @@ public interface FollowRepository {
     Follow findByFollowerAndFollowing(Member follower, Member following);
     void delete(Follow follow);
     List<Follow> findAllByFollowing(Member member);
+    List<Follow> findAllByFollower(Member member);
 }

--- a/src/main/java/com/coredisc/domain/follow/FollowRepository.java
+++ b/src/main/java/com/coredisc/domain/follow/FollowRepository.java
@@ -6,4 +6,6 @@ public interface FollowRepository {
 
     Follow save(Follow follow);
     boolean existsByFollowerAndFollowing(Member follower, Member following);
+    Follow findByFollowerAndFollowing(Member follower, Member following);
+    void delete(Follow follow);
 }

--- a/src/main/java/com/coredisc/domain/member/Member.java
+++ b/src/main/java/com/coredisc/domain/member/Member.java
@@ -71,11 +71,13 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private List<PostLike> likes = new ArrayList<>();
 
+    // 이 사용자가 팔로우하는 다른 사용자들과의 관계 목록
     @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL)
-    private List<Follow> followings = new ArrayList<>();
+    private List<Follow> followSentList = new ArrayList<>();
 
+    // 이 사용자를 팔로우하는 다른 사용자들과의 관계 목록
     @OneToMany(mappedBy = "following", cascade = CascadeType.ALL)
-    private List<Follow> followers = new ArrayList<>();
+    private List<Follow> followReceivedList = new ArrayList<>();
 
     // 메서드
     public void encodePassword(String password) {

--- a/src/main/java/com/coredisc/domain/member/Member.java
+++ b/src/main/java/com/coredisc/domain/member/Member.java
@@ -5,6 +5,7 @@ import com.coredisc.domain.Post;
 import com.coredisc.domain.PostLike;
 import com.coredisc.domain.common.BaseEntity;
 import com.coredisc.domain.common.enums.OauthType;
+import com.coredisc.domain.follow.Follow;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
@@ -62,6 +63,12 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member")
     private List<PostLike> likes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL)
+    private List<Follow> followings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "following", cascade = CascadeType.ALL)
+    private List<Follow> followers = new ArrayList<>();
 
     // 메서드
     public void encodePassword(String password) {

--- a/src/main/java/com/coredisc/domain/member/MemberRepository.java
+++ b/src/main/java/com/coredisc/domain/member/MemberRepository.java
@@ -1,9 +1,12 @@
 package com.coredisc.domain.member;
 
+import java.util.Optional;
+
 public interface MemberRepository {
 
     Member save(Member member);
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
+    Optional<Member> findById(Long followerId);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
@@ -1,0 +1,25 @@
+package com.coredisc.infrastructure.repository.follow;
+
+import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.follow.FollowRepository;
+import com.coredisc.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FollowRepositoryAdaptor implements FollowRepository {
+
+    private final JpaFollowRepository jpaFollowRepository;
+
+    @Override
+    public Follow save(Follow follow) {
+        return jpaFollowRepository.save(follow);
+    }
+
+    @Override
+    public boolean existsByFollowerAndFollowing(Member follower, Member following) {
+        return jpaFollowRepository.existsByFollowerAndFollowing(follower, following);
+    }
+
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
@@ -22,4 +22,14 @@ public class FollowRepositoryAdaptor implements FollowRepository {
         return jpaFollowRepository.existsByFollowerAndFollowing(follower, following);
     }
 
+    @Override
+    public Follow findByFollowerAndFollowing(Member follower, Member following) {
+        return jpaFollowRepository.findByFollowerAndFollowing(follower, following);
+    }
+
+    @Override
+    public void delete(Follow follow) {
+        jpaFollowRepository.delete(follow);
+    }
+
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
@@ -39,4 +39,9 @@ public class FollowRepositoryAdaptor implements FollowRepository {
         return jpaFollowRepository.findAllByFollowing(member);
     }
 
+    @Override
+    public List<Follow> findAllByFollower(Member member) {
+        return jpaFollowRepository.findAllByFollower(member);
+    }
+
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
@@ -6,6 +6,8 @@ import com.coredisc.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 public class FollowRepositoryAdaptor implements FollowRepository {
@@ -30,6 +32,11 @@ public class FollowRepositoryAdaptor implements FollowRepository {
     @Override
     public void delete(Follow follow) {
         jpaFollowRepository.delete(follow);
+    }
+
+    @Override
+    public List<Follow> findAllByFollowing(Member member) {
+        return jpaFollowRepository.findAllByFollowing(member);
     }
 
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
@@ -4,8 +4,11 @@ import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface JpaFollowRepository extends JpaRepository<Follow, Long> {
 
     boolean existsByFollowerAndFollowing(Member follower, Member following);
     Follow findByFollowerAndFollowing(Member follower, Member following);
+    List<Follow> findAllByFollowing(Member member);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
@@ -11,4 +11,5 @@ public interface JpaFollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByFollowerAndFollowing(Member follower, Member following);
     Follow findByFollowerAndFollowing(Member follower, Member following);
     List<Follow> findAllByFollowing(Member member);
+    List<Follow> findAllByFollower(Member member);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
@@ -1,0 +1,10 @@
+package com.coredisc.infrastructure.repository.follow;
+
+import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaFollowRepository extends JpaRepository<Follow, Long> {
+
+    boolean existsByFollowerAndFollowing(Member follower, Member following);
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface JpaFollowRepository extends JpaRepository<Follow, Long> {
 
     boolean existsByFollowerAndFollowing(Member follower, Member following);
+    Follow findByFollowerAndFollowing(Member follower, Member following);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/member/MemberRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/member/MemberRepositoryAdaptor.java
@@ -5,6 +5,8 @@ import com.coredisc.domain.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class MemberRepositoryAdaptor implements MemberRepository {
@@ -30,4 +32,7 @@ public class MemberRepositoryAdaptor implements MemberRepository {
     public boolean existsByNickname(String nickname) {
         return jpaMemberRepository.existsByNickname(nickname);
     }
+
+    @Override
+    public Optional<Member> findById(Long memberId) { return jpaMemberRepository.findById(memberId); }
 }

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -41,4 +41,11 @@ public class FollowController implements FollowControllerDocs {
         Long memberId = 1L;
         return ApiResponse.onSuccess(followQueryService.getFollowers(memberId));
     }
+
+    @GetMapping("/api/followings")
+    public ApiResponse<FollowResponseDTO.FollowingListViewDTO> getFollowings() {
+        // 하드코딩
+        Long memberId = 1L;
+        return ApiResponse.onSuccess(followQueryService.getFollowings(memberId));
+    }
 }

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -44,7 +44,9 @@ public class FollowController implements FollowControllerDocs {
             @CurrentMember Member member
     ) {
 
-        return ApiResponse.onSuccess(followQueryService.getFollowers(member));
+        return ApiResponse.onSuccess(FollowConverter.toFollowerListViewDTO(
+                followQueryService.getFollowers(member)
+        ));
     }
 
     @GetMapping("/api/followings")
@@ -52,6 +54,8 @@ public class FollowController implements FollowControllerDocs {
             @CurrentMember Member member
     ) {
 
-        return ApiResponse.onSuccess(followQueryService.getFollowings(member));
+        return ApiResponse.onSuccess(FollowConverter.toFollowingListViewDTO(
+                followQueryService.getFollowings(member)
+        ));
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -21,7 +21,7 @@ public class FollowController implements FollowControllerDocs {
     @PostMapping("/api/follow/{targetId}")
     public ApiResponse<FollowResponseDTO.FollowResultDTO> follow(
             @CurrentMember Member member,
-            @PathVariable long targetId
+            @PathVariable Long targetId
     ) {
 
         return ApiResponse.onSuccess(FollowConverter.toFollowResultDTO(
@@ -32,7 +32,7 @@ public class FollowController implements FollowControllerDocs {
     @DeleteMapping("/api/followings/{targetId}")
     public ApiResponse<?> unfollow(
             @CurrentMember Member member,
-            @PathVariable long targetId
+            @PathVariable Long targetId
     ) {
 
         followCommandService.unfollow(member, targetId);

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -3,6 +3,7 @@ package com.coredisc.presentation.controller;
 import com.coredisc.application.service.follow.FollowCommandService;
 import com.coredisc.application.service.follow.FollowQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.common.converter.FollowConverter;
 import com.coredisc.domain.follow.Follow;
 import com.coredisc.presentation.controllerdocs.FollowControllerDocs;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
@@ -18,10 +19,12 @@ public class FollowController implements FollowControllerDocs {
 
     //TODO: 하드코딩 수정
     @PostMapping("/api/follow/{targetId}")
-    public ApiResponse<Follow> follow(@PathVariable long targetId) {
+    public ApiResponse<FollowResponseDTO.FollowResultDTO> follow(@PathVariable long targetId) {
         // 하드코딩
         Long memberId = 1L;
-        return ApiResponse.onSuccess(followCommandService.follow(memberId, targetId));
+        return ApiResponse.onSuccess(FollowConverter.toFollowResultDTO(
+                followCommandService.follow(memberId, targetId)
+        ));
     }
 
     @DeleteMapping("/api/followings/{targetId}")

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -1,19 +1,20 @@
 package com.coredisc.presentation.controller;
 
 import com.coredisc.application.service.follow.FollowCommandService;
+import com.coredisc.application.service.follow.FollowQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.domain.follow.Follow;
 import com.coredisc.presentation.controllerdocs.FollowControllerDocs;
+import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 public class FollowController implements FollowControllerDocs {
 
     private final FollowCommandService followCommandService;
+    private final FollowQueryService followQueryService;
 
     //TODO: 하드코딩 수정
     @PostMapping("/api/follow/{followingId}")
@@ -29,5 +30,12 @@ public class FollowController implements FollowControllerDocs {
         Long followId = 1L;
         followCommandService.unfollow(followId, followingId);
         return ApiResponse.onSuccess(null);
+    }
+
+    @GetMapping("/api/followers")
+    public ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers() {
+        // 하드코딩
+        Long memberId = 1L;
+        return ApiResponse.onSuccess(followQueryService.getFollowers(memberId));
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -36,7 +36,7 @@ public class FollowController implements FollowControllerDocs {
     ) {
 
         followCommandService.unfollow(member, targetId);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.onSuccess("성공적으로 언팔로우되었습니다.");
     }
 
     @GetMapping("/api/followers")

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -17,18 +17,18 @@ public class FollowController implements FollowControllerDocs {
     private final FollowQueryService followQueryService;
 
     //TODO: 하드코딩 수정
-    @PostMapping("/api/follow/{followingId}")
-    public ApiResponse<Follow> follow(long followingId) {
+    @PostMapping("/api/follow/{targetId}")
+    public ApiResponse<Follow> follow(@PathVariable long targetId) {
         // 하드코딩
-        Long followId = 1L;
-        return ApiResponse.onSuccess(followCommandService.follow(followId, followingId));
+        Long memberId = 1L;
+        return ApiResponse.onSuccess(followCommandService.follow(memberId, targetId));
     }
 
-    @DeleteMapping("/api/followings/{followingId}")
-    public ApiResponse<?> unfollow(long followingId) {
+    @DeleteMapping("/api/followings/{targetId}")
+    public ApiResponse<?> unfollow(@PathVariable long targetId) {
         // 하드코딩
-        Long followId = 1L;
-        followCommandService.unfollow(followId, followingId);
+        Long memberId = 1L;
+        followCommandService.unfollow(memberId, targetId);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -4,9 +4,10 @@ import com.coredisc.application.service.follow.FollowCommandService;
 import com.coredisc.application.service.follow.FollowQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.common.converter.FollowConverter;
-import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.controllerdocs.FollowControllerDocs;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
+import com.coredisc.security.jwt.annotaion.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,33 +20,39 @@ public class FollowController implements FollowControllerDocs {
 
     //TODO: 하드코딩 수정
     @PostMapping("/api/follow/{targetId}")
-    public ApiResponse<FollowResponseDTO.FollowResultDTO> follow(@PathVariable long targetId) {
-        // 하드코딩
-        Long memberId = 1L;
+    public ApiResponse<FollowResponseDTO.FollowResultDTO> follow(
+            @CurrentMember Member member,
+            @PathVariable long targetId
+    ) {
+
         return ApiResponse.onSuccess(FollowConverter.toFollowResultDTO(
-                followCommandService.follow(memberId, targetId)
+                followCommandService.follow(member, targetId)
         ));
     }
 
     @DeleteMapping("/api/followings/{targetId}")
-    public ApiResponse<?> unfollow(@PathVariable long targetId) {
-        // 하드코딩
-        Long memberId = 1L;
-        followCommandService.unfollow(memberId, targetId);
+    public ApiResponse<?> unfollow(
+            @CurrentMember Member member,
+            @PathVariable long targetId
+    ) {
+
+        followCommandService.unfollow(member, targetId);
         return ApiResponse.onSuccess(null);
     }
 
     @GetMapping("/api/followers")
-    public ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers() {
-        // 하드코딩
-        Long memberId = 1L;
-        return ApiResponse.onSuccess(followQueryService.getFollowers(memberId));
+    public ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers(
+            @CurrentMember Member member
+    ) {
+
+        return ApiResponse.onSuccess(followQueryService.getFollowers(member));
     }
 
     @GetMapping("/api/followings")
-    public ApiResponse<FollowResponseDTO.FollowingListViewDTO> getFollowings() {
-        // 하드코딩
-        Long memberId = 1L;
-        return ApiResponse.onSuccess(followQueryService.getFollowings(memberId));
+    public ApiResponse<FollowResponseDTO.FollowingListViewDTO> getFollowings(
+            @CurrentMember Member member
+    ) {
+
+        return ApiResponse.onSuccess(followQueryService.getFollowings(member));
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -1,0 +1,24 @@
+package com.coredisc.presentation.controller;
+
+import com.coredisc.application.service.follow.FollowCommandService;
+import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.domain.follow.Follow;
+import com.coredisc.presentation.controllerdocs.FollowControllerDocs;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FollowController implements FollowControllerDocs {
+
+    private final FollowCommandService followCommandService;
+
+    //TODO: 하드코딩 수정
+    @PostMapping("/api/follow/{followingId}")
+    public ApiResponse<Follow> follow(long followingId) {
+        // 하드코딩
+        Long followId = 1L;
+        return ApiResponse.onSuccess(followCommandService.follow(followId, followingId));
+    }
+}

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -5,6 +5,7 @@ import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.domain.follow.Follow;
 import com.coredisc.presentation.controllerdocs.FollowControllerDocs;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +21,13 @@ public class FollowController implements FollowControllerDocs {
         // 하드코딩
         Long followId = 1L;
         return ApiResponse.onSuccess(followCommandService.follow(followId, followingId));
+    }
+
+    @DeleteMapping("/api/followings/{followingId}")
+    public ApiResponse<?> unfollow(long followingId) {
+        // 하드코딩
+        Long followId = 1L;
+        followCommandService.unfollow(followId, followingId);
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -18,7 +18,6 @@ public class FollowController implements FollowControllerDocs {
     private final FollowCommandService followCommandService;
     private final FollowQueryService followQueryService;
 
-    //TODO: 하드코딩 수정
     @PostMapping("/api/follow/{targetId}")
     public ApiResponse<FollowResponseDTO.FollowResultDTO> follow(
             @CurrentMember Member member,

--- a/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
@@ -11,4 +11,7 @@ public interface FollowControllerDocs {
 
     @Operation(summary = "팔로우", description = "팔로우 기능입니다.")
     ApiResponse<Follow> follow(@PathVariable long followingId);
+
+    @Operation(summary = "팔로우 취소", description = "팔로우 취소(팔로윙 삭제) 기능입니다.")
+    ApiResponse<?> unfollow(@PathVariable long followingId);
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
@@ -11,10 +11,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface FollowControllerDocs {
 
     @Operation(summary = "팔로우", description = "팔로우 기능입니다.")
-    ApiResponse<Follow> follow(@PathVariable long followingId);
+    ApiResponse<Follow> follow(@PathVariable long targetId);
 
     @Operation(summary = "팔로우 취소", description = "팔로우 취소(팔로윙 삭제) 기능입니다.")
-    ApiResponse<?> unfollow(@PathVariable long followingId);
+    ApiResponse<?> unfollow(@PathVariable long targetId);
 
     @Operation(summary = "팔로워 목록 조회", description = "팔로워 목록 조회 기능입니다.")
     ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers();

--- a/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
@@ -17,4 +17,7 @@ public interface FollowControllerDocs {
 
     @Operation(summary = "팔로워 목록 조회", description = "팔로워 목록 조회 기능입니다.")
     ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers();
+
+    @Operation(summary = "팔로잉 목록 조회", description = "팔로잉 목록 조회 기능입니다.")
+    ApiResponse<FollowResponseDTO.FollowingListViewDTO> getFollowings();
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
@@ -12,10 +12,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface FollowControllerDocs {
 
     @Operation(summary = "팔로우", description = "팔로우 기능입니다.")
-    ApiResponse<FollowResponseDTO.FollowResultDTO> follow(@CurrentMember Member member, @PathVariable long targetId);
+    ApiResponse<FollowResponseDTO.FollowResultDTO> follow(@CurrentMember Member member, @PathVariable Long targetId);
 
     @Operation(summary = "팔로우 취소", description = "팔로우 취소(팔로윙 삭제) 기능입니다.")
-    ApiResponse<?> unfollow(@CurrentMember Member member, @PathVariable long targetId);
+    ApiResponse<?> unfollow(@CurrentMember Member member, @PathVariable Long targetId);
 
     @Operation(summary = "팔로워 목록 조회", description = "팔로워 목록 조회 기능입니다.")
     ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers(@CurrentMember Member member);

--- a/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
@@ -1,7 +1,6 @@
 package com.coredisc.presentation.controllerdocs;
 
 import com.coredisc.common.apiPayload.ApiResponse;
-import com.coredisc.domain.follow.Follow;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,7 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface FollowControllerDocs {
 
     @Operation(summary = "팔로우", description = "팔로우 기능입니다.")
-    ApiResponse<Follow> follow(@PathVariable long targetId);
+    ApiResponse<FollowResponseDTO.FollowResultDTO> follow(@PathVariable long targetId);
 
     @Operation(summary = "팔로우 취소", description = "팔로우 취소(팔로윙 삭제) 기능입니다.")
     ApiResponse<?> unfollow(@PathVariable long targetId);

--- a/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
@@ -2,6 +2,7 @@ package com.coredisc.presentation.controllerdocs;
 
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.domain.follow.Follow;
+import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,4 +15,7 @@ public interface FollowControllerDocs {
 
     @Operation(summary = "팔로우 취소", description = "팔로우 취소(팔로윙 삭제) 기능입니다.")
     ApiResponse<?> unfollow(@PathVariable long followingId);
+
+    @Operation(summary = "팔로워 목록 조회", description = "팔로워 목록 조회 기능입니다.")
+    ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers();
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
@@ -1,7 +1,9 @@
 package com.coredisc.presentation.controllerdocs;
 
 import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
+import com.coredisc.security.jwt.annotaion.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,14 +12,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface FollowControllerDocs {
 
     @Operation(summary = "팔로우", description = "팔로우 기능입니다.")
-    ApiResponse<FollowResponseDTO.FollowResultDTO> follow(@PathVariable long targetId);
+    ApiResponse<FollowResponseDTO.FollowResultDTO> follow(@CurrentMember Member member, @PathVariable long targetId);
 
     @Operation(summary = "팔로우 취소", description = "팔로우 취소(팔로윙 삭제) 기능입니다.")
-    ApiResponse<?> unfollow(@PathVariable long targetId);
+    ApiResponse<?> unfollow(@CurrentMember Member member, @PathVariable long targetId);
 
     @Operation(summary = "팔로워 목록 조회", description = "팔로워 목록 조회 기능입니다.")
-    ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers();
+    ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers(@CurrentMember Member member);
 
     @Operation(summary = "팔로잉 목록 조회", description = "팔로잉 목록 조회 기능입니다.")
-    ApiResponse<FollowResponseDTO.FollowingListViewDTO> getFollowings();
+    ApiResponse<FollowResponseDTO.FollowingListViewDTO> getFollowings(@CurrentMember Member member);
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
@@ -1,0 +1,14 @@
+package com.coredisc.presentation.controllerdocs;
+
+import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.domain.follow.Follow;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Follow", description = "팔로우 관련 API")
+public interface FollowControllerDocs {
+
+    @Operation(summary = "팔로우", description = "팔로우 기능입니다.")
+    ApiResponse<Follow> follow(@PathVariable long followingId);
+}

--- a/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class FollowResponseDTO {
@@ -45,6 +46,17 @@ public class FollowResponseDTO {
     @Builder
     public static class FollowingListViewDTO {
         private List<FollowingDTO> followings;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class FollowResultDTO {
+        private Long id;
+        private Long followerId;
+        private Long followingId;
+        private LocalDateTime createdAt;
     }
 
 }

--- a/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
@@ -19,6 +19,7 @@ public class FollowResponseDTO {
         private String followerNickname;
         private String followerUsername;
         private String followerImageUrl;
+        private boolean isCircle;
     }
 
     @Getter
@@ -38,6 +39,7 @@ public class FollowResponseDTO {
         private String followingNickname;
         private String followingUsername;
         private String followingImageUrl;
+        private boolean isCircle;
     }
 
     @Getter

--- a/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
@@ -27,6 +27,7 @@ public class FollowResponseDTO {
     @NoArgsConstructor
     @Builder
     public static class FollowerListViewDTO {
+        private int totalFollowerCount;
         private List<FollowerDTO> followers;
     }
 
@@ -47,6 +48,7 @@ public class FollowResponseDTO {
     @NoArgsConstructor
     @Builder
     public static class FollowingListViewDTO {
+        private int totalFollowingCount;
         private List<FollowingDTO> followings;
     }
 

--- a/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
@@ -19,7 +19,6 @@ public class FollowResponseDTO {
         private String followerNickname;
         private String followerUsername;
         private String followerImageUrl;
-        private boolean isCircle;
     }
 
     @Getter

--- a/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
@@ -1,0 +1,50 @@
+package com.coredisc.presentation.dto.follow;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class FollowResponseDTO {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class FollowerDTO {
+        private Long followerId;
+        private String followerNickname;
+        private String followerUsername;
+        private String followerImageUrl;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class FollowerListViewDTO {
+        private List<FollowerDTO> followers;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class FollowingDTO {
+        private Long followingId;
+        private String followingNickname;
+        private String followingUsername;
+        private String followingImageUrl;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class FollowingListViewDTO {
+        private List<FollowingDTO> followings;
+    }
+
+}


### PR DESCRIPTION
## 💡 작업 내용 요약
어떤 기능/버그/리팩토링을 했는지 요약해주세요.

팔로우 관련 API 구현
- 팔로우
- 언팔로우
- 팔로워 목록 조회
- 팔로잉 목록 조회

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #16 

## 📎 기타 참고사항
1. 팔로워/팔로잉 목록 조회 시, 총 팔로워/팔로잉 수를 함께 반환하도록 수정했습니다.
2. 프로필 이미지 부분은 S3 설정 후 구현하는 것으로 생각하고 현재 비워둔 상태입니다. 이렇게 진행해도 괜찮을지 확인 부탁드립니다.
3. 저도 이번 구조는 처음이라서요..! 프로젝트 구조나 패키지 구성 또는 다양한 피드백 주시면 감사하겠습니다!
