### PR TITLE
Feat: 마이홈(본인)/마이홈(타사용자) 정보 확인 API 구현, 회원가입 로직 수정(기본 프로필 이미지 적용)

### DIFF
--- a/src/main/java/com/coredisc/application/service/member/MemberQueryService.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberQueryService.java
@@ -2,8 +2,13 @@ package com.coredisc.application.service.member;
 
 
 import com.coredisc.domain.member.Member;
+import com.coredisc.presentation.dto.member.MemberResponseDTO;
 
 public interface MemberQueryService {
+
     // CurrentMemberResolver를 위해 Member 찾기
     Member getMemberByUsername(String username);
+
+    // 마이홈(본인) 사용자 정보 확인
+    MemberResponseDTO.MyHomeUserInfoDTO getMyHomeUserInfo(Member member);
 }

--- a/src/main/java/com/coredisc/application/service/member/MemberQueryService.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberQueryService.java
@@ -10,5 +10,8 @@ public interface MemberQueryService {
     Member getMemberByUsername(String username);
 
     // 마이홈(본인) 사용자 정보 확인
-    MemberResponseDTO.MyHomeUserInfoDTO getMyHomeUserInfo(Member member);
+    MemberResponseDTO.MyHomeInfoOfMeDTO getMyHomeInfoOfMe(Member member);
+
+    // 마이홈(타사용자) 사용자 정보 확인
+    MemberResponseDTO.MyHomeInfoOfOtherDTO getMyHomeInfoOfOther(Member member, String targetUsername);
 }

--- a/src/main/java/com/coredisc/application/service/member/MemberQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberQueryServiceImpl.java
@@ -1,9 +1,14 @@
 package com.coredisc.application.service.member;
 
 import com.coredisc.common.apiPayload.status.ErrorStatus;
+import com.coredisc.common.converter.MemberConverter;
 import com.coredisc.common.exception.handler.AuthHandler;
+import com.coredisc.domain.follow.FollowRepository;
 import com.coredisc.domain.member.Member;
-import com.coredisc.infrastructure.repository.member.JpaMemberRepository;
+import com.coredisc.domain.member.MemberRepository;
+import com.coredisc.domain.profileImg.ProfileImg;
+import com.coredisc.domain.profileImg.ProfileImgRepository;
+import com.coredisc.presentation.dto.member.MemberResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,10 +16,31 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MemberQueryServiceImpl implements MemberQueryService {
 
-    private final JpaMemberRepository memberRepository;
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+    private final ProfileImgRepository profileImgRepository;
+
+
     @Override
     public Member getMemberByUsername(String username) {
         return memberRepository.findByUsername(username)
                 .orElseThrow(() -> new AuthHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    @Override
+    public MemberResponseDTO.MyHomeUserInfoDTO getMyHomeUserInfo(Member member) {
+
+        // 사용자의 팔로워 수
+        Long followerCount = followRepository.countByFollowingId(member.getId());
+
+        // 사용자의 팔로잉 수
+        Long followingCount = followRepository.countByFollowerId(member.getId());
+
+        // TODO: 총 디스크(월별 리포트 수)
+
+        // 사용자의 프로필 이미지
+        ProfileImg profileImg = profileImgRepository.findByMember(member);
+
+        return MemberConverter.toMyHomeUserInfoDTO(member, followerCount, followingCount, profileImg);
     }
 }

--- a/src/main/java/com/coredisc/application/service/member/MemberQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.coredisc.application.service.member;
 import com.coredisc.common.apiPayload.status.ErrorStatus;
 import com.coredisc.common.converter.MemberConverter;
 import com.coredisc.common.exception.handler.AuthHandler;
+import com.coredisc.common.exception.handler.MemberHandler;
 import com.coredisc.domain.follow.FollowRepository;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.member.MemberRepository;
@@ -28,7 +29,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     }
 
     @Override
-    public MemberResponseDTO.MyHomeUserInfoDTO getMyHomeUserInfo(Member member) {
+    public MemberResponseDTO.MyHomeInfoOfMeDTO getMyHomeInfoOfMe(Member member) {
 
         // 사용자의 팔로워 수
         Long followerCount = followRepository.countByFollowingId(member.getId());
@@ -41,6 +42,30 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         // 사용자의 프로필 이미지
         ProfileImg profileImg = profileImgRepository.findByMember(member);
 
-        return MemberConverter.toMyHomeUserInfoDTO(member, followerCount, followingCount, profileImg);
+        return MemberConverter.toMyHomeInfoOfMeDTO(member, followerCount, followingCount, profileImg);
+    }
+
+    @Override
+    public MemberResponseDTO.MyHomeInfoOfOtherDTO getMyHomeInfoOfOther(Member member, String targetUsername) {
+
+        // 타사용자
+        Member targetMember = memberRepository.findByUsername(targetUsername)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 타사용자의 팔로워 수
+        Long followerCount = followRepository.countByFollowingId(targetMember.getId());
+
+        // 타사용자의 팔로잉 수
+        Long followingCount = followRepository.countByFollowerId(targetMember.getId());
+
+        // TODO: 총 디스크(월별 리포트 수)
+
+        // 타사용자의 프로필 이미지
+        ProfileImg profileImg = profileImgRepository.findByMember(targetMember);
+
+        // 팔로우 여부
+        Boolean isFollowing = followRepository.existsByFollowerAndFollowing(member, targetMember);
+
+        return MemberConverter.toMyHomeInfoOfOtherDTO(targetMember, followerCount, followingCount, profileImg, isFollowing);
     }
 }

--- a/src/main/java/com/coredisc/application/service/member/MemberQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberQueryServiceImpl.java
@@ -7,6 +7,7 @@ import com.coredisc.common.exception.handler.MemberHandler;
 import com.coredisc.domain.follow.FollowRepository;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.member.MemberRepository;
+import com.coredisc.domain.monthlyReport.MonthlyReportRepository;
 import com.coredisc.domain.profileImg.ProfileImg;
 import com.coredisc.domain.profileImg.ProfileImgRepository;
 import com.coredisc.presentation.dto.member.MemberResponseDTO;
@@ -20,6 +21,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
     private final ProfileImgRepository profileImgRepository;
+    private final MonthlyReportRepository monthlyReportRepository;
 
 
     @Override
@@ -37,12 +39,13 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         // 사용자의 팔로잉 수
         Long followingCount = followRepository.countByFollowerId(member.getId());
 
-        // TODO: 총 디스크(월별 리포트 수)
+        // 총 디스크 수(월별 리포트 수)
+        Long discCount = monthlyReportRepository.countByMember(member);
 
         // 사용자의 프로필 이미지
         ProfileImg profileImg = profileImgRepository.findByMember(member);
 
-        return MemberConverter.toMyHomeInfoOfMeDTO(member, followerCount, followingCount, profileImg);
+        return MemberConverter.toMyHomeInfoOfMeDTO(member, followerCount, followingCount, discCount, profileImg);
     }
 
     @Override
@@ -58,7 +61,8 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         // 타사용자의 팔로잉 수
         Long followingCount = followRepository.countByFollowerId(targetMember.getId());
 
-        // TODO: 총 디스크(월별 리포트 수)
+        // 총 디스크 수(월별 리포트 수)
+        Long discCount = monthlyReportRepository.countByMember(targetMember);
 
         // 타사용자의 프로필 이미지
         ProfileImg profileImg = profileImgRepository.findByMember(targetMember);
@@ -66,6 +70,6 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         // 팔로우 여부
         Boolean isFollowing = followRepository.existsByFollowerAndFollowing(member, targetMember);
 
-        return MemberConverter.toMyHomeInfoOfOtherDTO(targetMember, followerCount, followingCount, profileImg, isFollowing);
+        return MemberConverter.toMyHomeInfoOfOtherDTO(targetMember, followerCount, followingCount, discCount, profileImg, isFollowing);
     }
 }

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -41,6 +41,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 이용 약관 관련 에러
     TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "TERMS4001", "존재하지 않는 이용 약관 항목입니다."),
 
+    // 프로필 이미지 관련 에러
+    DEFAULT_PROFILE_IMG_NOT_FOUND(HttpStatus.NOT_FOUND, "PROFILE_IMG4001", "기본 프로필 이미지가 존재하지 않습니다."),
+
     // For test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트 용도");
 

--- a/src/main/java/com/coredisc/common/converter/MemberConverter.java
+++ b/src/main/java/com/coredisc/common/converter/MemberConverter.java
@@ -87,22 +87,47 @@ public class MemberConverter {
                 .build();
     }
 
-    public static MemberResponseDTO.MyHomeUserInfoDTO toMyHomeUserInfoDTO(Member member, Long follwerCount,
+    public static MemberResponseDTO.MyHomeInfoOfMeDTO toMyHomeInfoOfMeDTO(Member member, Long followerCount,
                                                                           Long followingCount, ProfileImg profileImg) {
-
         // 가입 시기 M.d.yyyy 형태로 변환
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M.d.yyyy");
-        String formattedDate = member.getCreatedAt().format(formatter);
+        String formattedDate = formatJoinDate(member);
 
-        return MemberResponseDTO.MyHomeUserInfoDTO.builder()
+        return MemberResponseDTO.MyHomeInfoOfMeDTO.builder()
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .joinDate(formattedDate)
-                .followerCount(follwerCount)
+                .followerCount(followerCount)
                 .followingCount(followingCount)
                 // TODO: 총 디스크 수
 //                .discCount(discCount)
                 .profileImgDTO(ProfileImgConverter.toProfileImgDTO(profileImg))
                 .build();
+    }
+
+    public static MemberResponseDTO.MyHomeInfoOfOtherDTO toMyHomeInfoOfOtherDTO(Member targetMember, Long followerCount,
+                                                                                Long followingCount, ProfileImg profileImg,
+                                                                                Boolean isFollowing) {
+        // 가입 시기 M.d.yyyy 형태로 변환
+        String formattedDate = formatJoinDate(targetMember);
+
+        return MemberResponseDTO.MyHomeInfoOfOtherDTO.builder()
+                .memberId(targetMember.getId())
+                .nickname(targetMember.getNickname())
+                .joinDate(formattedDate)
+                .followerCount(followerCount)
+                .followingCount(followingCount)
+                // TODO: 총 디스크 수
+//                .discCount(discCount)
+                .isFollowing(isFollowing)
+                .profileImgDTO(ProfileImgConverter.toProfileImgDTO(profileImg))
+                .build();
+    }
+
+    // 날짜 M.d.yyyy 형태로 변환
+    private static String formatJoinDate(Member member) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M.d.yyyy");
+
+        return member.getCreatedAt().format(formatter);
     }
 }

--- a/src/main/java/com/coredisc/common/converter/MemberConverter.java
+++ b/src/main/java/com/coredisc/common/converter/MemberConverter.java
@@ -3,10 +3,13 @@ package com.coredisc.common.converter;
 import com.coredisc.common.util.RandomNicknameGenerator;
 import com.coredisc.domain.common.enums.Role;
 import com.coredisc.domain.member.Member;
+import com.coredisc.domain.profileImg.ProfileImg;
 import com.coredisc.presentation.dto.auth.AuthRequestDTO;
 import com.coredisc.presentation.dto.auth.AuthResponseDTO;
+import com.coredisc.presentation.dto.member.MemberResponseDTO;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 
 public class MemberConverter {
@@ -81,6 +84,25 @@ public class MemberConverter {
 
         return AuthResponseDTO.FindUsernameResultDTO.builder()
                 .username(member.getUsername())
+                .build();
+    }
+
+    public static MemberResponseDTO.MyHomeUserInfoDTO toMyHomeUserInfoDTO(Member member, Long follwerCount,
+                                                                          Long followingCount, ProfileImg profileImg) {
+
+        // 가입 시기 M.d.yyyy 형태로 변환
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M.d.yyyy");
+        String formattedDate = member.getCreatedAt().format(formatter);
+
+        return MemberResponseDTO.MyHomeUserInfoDTO.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .joinDate(formattedDate)
+                .followerCount(follwerCount)
+                .followingCount(followingCount)
+                // TODO: 총 디스크 수
+//                .discCount(discCount)
+                .profileImgDTO(ProfileImgConverter.toProfileImgDTO(profileImg))
                 .build();
     }
 }

--- a/src/main/java/com/coredisc/common/converter/MemberConverter.java
+++ b/src/main/java/com/coredisc/common/converter/MemberConverter.java
@@ -88,7 +88,8 @@ public class MemberConverter {
     }
 
     public static MemberResponseDTO.MyHomeInfoOfMeDTO toMyHomeInfoOfMeDTO(Member member, Long followerCount,
-                                                                          Long followingCount, ProfileImg profileImg) {
+                                                                          Long followingCount, Long discCount,
+                                                                          ProfileImg profileImg) {
         // 가입 시기 M.d.yyyy 형태로 변환
         String formattedDate = formatJoinDate(member);
 
@@ -98,15 +99,14 @@ public class MemberConverter {
                 .joinDate(formattedDate)
                 .followerCount(followerCount)
                 .followingCount(followingCount)
-                // TODO: 총 디스크 수
-//                .discCount(discCount)
+                .discCount(discCount)
                 .profileImgDTO(ProfileImgConverter.toProfileImgDTO(profileImg))
                 .build();
     }
 
     public static MemberResponseDTO.MyHomeInfoOfOtherDTO toMyHomeInfoOfOtherDTO(Member targetMember, Long followerCount,
-                                                                                Long followingCount, ProfileImg profileImg,
-                                                                                Boolean isFollowing) {
+                                                                                Long followingCount, Long discCount,
+                                                                                ProfileImg profileImg, Boolean isFollowing) {
         // 가입 시기 M.d.yyyy 형태로 변환
         String formattedDate = formatJoinDate(targetMember);
 
@@ -116,8 +116,7 @@ public class MemberConverter {
                 .joinDate(formattedDate)
                 .followerCount(followerCount)
                 .followingCount(followingCount)
-                // TODO: 총 디스크 수
-//                .discCount(discCount)
+                .discCount(discCount)
                 .isFollowing(isFollowing)
                 .profileImgDTO(ProfileImgConverter.toProfileImgDTO(profileImg))
                 .build();

--- a/src/main/java/com/coredisc/common/converter/ProfileImgConverter.java
+++ b/src/main/java/com/coredisc/common/converter/ProfileImgConverter.java
@@ -1,0 +1,15 @@
+package com.coredisc.common.converter;
+
+import com.coredisc.domain.profileImg.ProfileImg;
+import com.coredisc.presentation.dto.profileImg.ProfileImgResponseDTO;
+
+public class ProfileImgConverter {
+
+    public static ProfileImgResponseDTO.ProfileImgDTO toProfileImgDTO(ProfileImg profileImg) {
+
+        return ProfileImgResponseDTO.ProfileImgDTO.builder()
+                .profileImgId(profileImg.getId())
+                .imageUrl(profileImg.getImgUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/coredisc/common/converter/ProfileImgConverter.java
+++ b/src/main/java/com/coredisc/common/converter/ProfileImgConverter.java
@@ -1,5 +1,6 @@
 package com.coredisc.common.converter;
 
+import com.coredisc.domain.member.Member;
 import com.coredisc.domain.profileImg.ProfileImg;
 import com.coredisc.presentation.dto.profileImg.ProfileImgResponseDTO;
 
@@ -10,6 +11,14 @@ public class ProfileImgConverter {
         return ProfileImgResponseDTO.ProfileImgDTO.builder()
                 .profileImgId(profileImg.getId())
                 .imageUrl(profileImg.getImgUrl())
+                .build();
+    }
+
+    public static ProfileImg toProfileImg(Member member, ProfileImg defaultProfileImg) {
+
+        return ProfileImg.builder()
+                .imgUrl(defaultProfileImg.getImgUrl())
+                .member(member)
                 .build();
     }
 }

--- a/src/main/java/com/coredisc/common/exception/handler/MemberHandler.java
+++ b/src/main/java/com/coredisc/common/exception/handler/MemberHandler.java
@@ -1,0 +1,10 @@
+package com.coredisc.common.exception.handler;
+
+import com.coredisc.common.apiPayload.code.BaseErrorCode;
+import com.coredisc.common.exception.GeneralException;
+
+public class MemberHandler extends GeneralException {
+    public MemberHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/coredisc/common/exception/handler/ProfileImgHandler.java
+++ b/src/main/java/com/coredisc/common/exception/handler/ProfileImgHandler.java
@@ -1,0 +1,10 @@
+package com.coredisc.common.exception.handler;
+
+import com.coredisc.common.apiPayload.code.BaseErrorCode;
+import com.coredisc.common.exception.GeneralException;
+
+public class ProfileImgHandler extends GeneralException {
+    public ProfileImgHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/coredisc/domain/common/BaseEntity.java
+++ b/src/main/java/com/coredisc/domain/common/BaseEntity.java
@@ -3,6 +3,7 @@ package com.coredisc.domain.common;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -10,6 +11,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public  class BaseEntity {

--- a/src/main/java/com/coredisc/domain/follow/Follow.java
+++ b/src/main/java/com/coredisc/domain/follow/Follow.java
@@ -1,4 +1,4 @@
-package com.coredisc.domain;
+package com.coredisc.domain.follow;
 
 import com.coredisc.domain.common.BaseEntity;
 import com.coredisc.domain.member.Member;

--- a/src/main/java/com/coredisc/domain/follow/FollowRepository.java
+++ b/src/main/java/com/coredisc/domain/follow/FollowRepository.java
@@ -1,5 +1,7 @@
 package com.coredisc.domain.follow;
 
+import com.coredisc.domain.member.Member;
+
 public interface FollowRepository {
 
     // 사용자의 팔로잉 수 구하기
@@ -7,4 +9,8 @@ public interface FollowRepository {
 
     // 사용자의 팔로워 수 구하기
     Long countByFollowingId(Long memberId);
+
+    // 팔로우 여부
+    Boolean existsByFollowerAndFollowing(Member member, Member targetMember);
+
 }

--- a/src/main/java/com/coredisc/domain/follow/FollowRepository.java
+++ b/src/main/java/com/coredisc/domain/follow/FollowRepository.java
@@ -1,0 +1,10 @@
+package com.coredisc.domain.follow;
+
+public interface FollowRepository {
+
+    // 사용자의 팔로잉 수 구하기
+    Long countByFollowerId(Long memberId);
+
+    // 사용자의 팔로워 수 구하기
+    Long countByFollowingId(Long memberId);
+}

--- a/src/main/java/com/coredisc/domain/member/Member.java
+++ b/src/main/java/com/coredisc/domain/member/Member.java
@@ -7,6 +7,7 @@ import com.coredisc.domain.common.BaseEntity;
 import com.coredisc.domain.common.enums.OauthType;
 import com.coredisc.domain.common.enums.Role;
 import com.coredisc.domain.mapping.MemberTerms;
+import com.coredisc.domain.profileImg.ProfileImg;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
@@ -62,6 +63,10 @@ public class Member extends BaseEntity {
     private String oauthKey;
 
     // 연관관계 매핑
+    @Setter
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private ProfileImg profileImg;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Post> posts = new ArrayList<>();
 

--- a/src/main/java/com/coredisc/domain/member/Member.java
+++ b/src/main/java/com/coredisc/domain/member/Member.java
@@ -7,6 +7,7 @@ import com.coredisc.domain.common.BaseEntity;
 import com.coredisc.domain.common.enums.OauthType;
 import com.coredisc.domain.common.enums.Role;
 import com.coredisc.domain.mapping.MemberTerms;
+import com.coredisc.domain.monthlyReport.MonthlyReport;
 import com.coredisc.domain.profileImg.ProfileImg;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
@@ -78,6 +79,9 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<MemberTerms> memberTermsList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MonthlyReport> monthlyReportList = new ArrayList<>();
 
     // 메서드
     public void encodePassword(String password) {

--- a/src/main/java/com/coredisc/domain/monthlyReport/MonthlyReport.java
+++ b/src/main/java/com/coredisc/domain/monthlyReport/MonthlyReport.java
@@ -1,0 +1,26 @@
+package com.coredisc.domain.monthlyReport;
+
+import com.coredisc.domain.common.BaseEntity;
+import com.coredisc.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MonthlyReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // TODO: 다른 필드 추가
+
+    // 연관 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+}

--- a/src/main/java/com/coredisc/domain/monthlyReport/MonthlyReportRepository.java
+++ b/src/main/java/com/coredisc/domain/monthlyReport/MonthlyReportRepository.java
@@ -1,0 +1,8 @@
+package com.coredisc.domain.monthlyReport;
+
+import com.coredisc.domain.member.Member;
+
+public interface MonthlyReportRepository {
+
+    Long countByMember(Member member);
+}

--- a/src/main/java/com/coredisc/domain/profileImg/ProfileImg.java
+++ b/src/main/java/com/coredisc/domain/profileImg/ProfileImg.java
@@ -1,6 +1,7 @@
-package com.coredisc.domain;
+package com.coredisc.domain.profileImg;
 
 import com.coredisc.domain.common.BaseEntity;
+import com.coredisc.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -15,6 +16,12 @@ public class ProfileImg extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // TODO: 연관관계 설정, 엔티티 정의하고 todo 제거해주세요.
-    // - @OneToOne Member
+    @Lob
+    @Column(nullable = false, length = 256)
+    private String imgUrl;
+
+    // 연관 관계
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 }

--- a/src/main/java/com/coredisc/domain/profileImg/ProfileImgRepository.java
+++ b/src/main/java/com/coredisc/domain/profileImg/ProfileImgRepository.java
@@ -1,0 +1,8 @@
+package com.coredisc.domain.profileImg;
+
+import com.coredisc.domain.member.Member;
+
+public interface ProfileImgRepository {
+
+    ProfileImg findByMember(Member member);
+}

--- a/src/main/java/com/coredisc/domain/profileImg/ProfileImgRepository.java
+++ b/src/main/java/com/coredisc/domain/profileImg/ProfileImgRepository.java
@@ -2,7 +2,10 @@ package com.coredisc.domain.profileImg;
 
 import com.coredisc.domain.member.Member;
 
+import java.util.Optional;
+
 public interface ProfileImgRepository {
 
     ProfileImg findByMember(Member member);
+    Optional<ProfileImg> findById(Long profileImgId);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
@@ -1,6 +1,7 @@
 package com.coredisc.infrastructure.repository.follow;
 
 import com.coredisc.domain.follow.FollowRepository;
+import com.coredisc.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -18,5 +19,10 @@ public class FollowRepositoryAdaptor implements FollowRepository {
     @Override
     public Long countByFollowingId(Long memberId) {
         return jpaFollowRepository.countByFollowingId(memberId);
+    }
+
+    @Override
+    public Boolean existsByFollowerAndFollowing(Member member, Member targetMember) {
+        return jpaFollowRepository.existsByFollowerAndFollowing(member, targetMember);
     }
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
@@ -1,0 +1,22 @@
+package com.coredisc.infrastructure.repository.follow;
+
+import com.coredisc.domain.follow.FollowRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FollowRepositoryAdaptor implements FollowRepository {
+
+    private final JpaFollowRepository jpaFollowRepository;
+
+    @Override
+    public Long countByFollowerId(Long memberId) {
+        return jpaFollowRepository.countByFollowerId(memberId);
+    }
+
+    @Override
+    public Long countByFollowingId(Long memberId) {
+        return jpaFollowRepository.countByFollowingId(memberId);
+    }
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
@@ -1,6 +1,7 @@
 package com.coredisc.infrastructure.repository.follow;
 
 import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaFollowRepository extends JpaRepository<Follow, Long> {
@@ -8,4 +9,6 @@ public interface JpaFollowRepository extends JpaRepository<Follow, Long> {
     Long countByFollowerId(Long followerId);
 
     Long countByFollowingId(Long memberId);
+
+    Boolean existsByFollowerAndFollowing(Member member, Member targetMember);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
@@ -1,0 +1,11 @@
+package com.coredisc.infrastructure.repository.follow;
+
+import com.coredisc.domain.follow.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaFollowRepository extends JpaRepository<Follow, Long> {
+
+    Long countByFollowerId(Long followerId);
+
+    Long countByFollowingId(Long memberId);
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/monthlyReport/JpaMonthlyReportRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/monthlyReport/JpaMonthlyReportRepository.java
@@ -1,0 +1,10 @@
+package com.coredisc.infrastructure.repository.monthlyReport;
+
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.monthlyReport.MonthlyReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaMonthlyReportRepository extends JpaRepository<MonthlyReport, Long> {
+
+    Long countByMember(Member member);
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/monthlyReport/MonthlyReportRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/monthlyReport/MonthlyReportRepositoryAdaptor.java
@@ -1,0 +1,19 @@
+package com.coredisc.infrastructure.repository.monthlyReport;
+
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.monthlyReport.MonthlyReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MonthlyReportRepositoryAdaptor implements MonthlyReportRepository {
+
+    private final JpaMonthlyReportRepository jpaMonthlyReportRepository;
+
+    @Override
+    public Long countByMember(Member member) {
+
+        return jpaMonthlyReportRepository.countByMember(member);
+    }
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/profileImg/JpaProfileImgRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/profileImg/JpaProfileImgRepository.java
@@ -1,0 +1,10 @@
+package com.coredisc.infrastructure.repository.profileImg;
+
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.profileImg.ProfileImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaProfileImgRepository extends JpaRepository<ProfileImg, Long> {
+
+    ProfileImg findByMember(Member member);
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/profileImg/ProfileImgRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/profileImg/ProfileImgRepositoryAdaptor.java
@@ -1,0 +1,19 @@
+package com.coredisc.infrastructure.repository.profileImg;
+
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.profileImg.ProfileImg;
+import com.coredisc.domain.profileImg.ProfileImgRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProfileImgRepositoryAdaptor implements ProfileImgRepository {
+
+    private final JpaProfileImgRepository jpaProfileImgRepository;
+
+    @Override
+    public ProfileImg findByMember(Member member) {
+        return jpaProfileImgRepository.findByMember(member);
+    }
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/profileImg/ProfileImgRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/profileImg/ProfileImgRepositoryAdaptor.java
@@ -6,6 +6,8 @@ import com.coredisc.domain.profileImg.ProfileImgRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class ProfileImgRepositoryAdaptor implements ProfileImgRepository {
@@ -15,5 +17,10 @@ public class ProfileImgRepositoryAdaptor implements ProfileImgRepository {
     @Override
     public ProfileImg findByMember(Member member) {
         return jpaProfileImgRepository.findByMember(member);
+    }
+
+    @Override
+    public Optional<ProfileImg> findById(Long profileImgId) {
+        return jpaProfileImgRepository.findById(profileImgId);
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/MemberController.java
+++ b/src/main/java/com/coredisc/presentation/controller/MemberController.java
@@ -39,7 +39,7 @@ public class MemberController implements MemberControllerDocs {
 
     @Override
     @PatchMapping("/resign")
-    public ApiResponse<String> resignMember(Member member) {
+    public ApiResponse<String> resignMember(@CurrentMember Member member) {
 
         memberCommandService.resignMember(member);
         return ApiResponse.onSuccess("계정이 탈퇴되었습니다.");
@@ -47,8 +47,16 @@ public class MemberController implements MemberControllerDocs {
 
     @Override
     @GetMapping("/my-home")
-    public ApiResponse<MemberResponseDTO.MyHomeUserInfoDTO> getMyHomeUserInfo(Member member) {
+    public ApiResponse<MemberResponseDTO.MyHomeInfoOfMeDTO> getMyHomeInfoOfMe(@CurrentMember Member member) {
 
-        return ApiResponse.onSuccess(memberQueryService.getMyHomeUserInfo(member));
+        return ApiResponse.onSuccess(memberQueryService.getMyHomeInfoOfMe(member));
+    }
+
+    @Override
+    @GetMapping("/my-home/{targetUsername}")
+    public ApiResponse<MemberResponseDTO.MyHomeInfoOfOtherDTO> getMyHomeInfoOfOther(@CurrentMember Member member,
+                                                                                 @PathVariable String targetUsername) {
+
+        return ApiResponse.onSuccess(memberQueryService.getMyHomeInfoOfOther(member, targetUsername));
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/MemberController.java
+++ b/src/main/java/com/coredisc/presentation/controller/MemberController.java
@@ -1,17 +1,16 @@
 package com.coredisc.presentation.controller;
 
 import com.coredisc.application.service.member.MemberCommandService;
+import com.coredisc.application.service.member.MemberQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.controllerdocs.MemberControllerDocs;
 import com.coredisc.presentation.dto.member.MemberRequestDTO;
+import com.coredisc.presentation.dto.member.MemberResponseDTO;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/members")
@@ -19,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController implements MemberControllerDocs {
 
     private final MemberCommandService memberCommandService;
+    private final MemberQueryService memberQueryService;
 
     @Override
     @PatchMapping("/password")
@@ -43,5 +43,12 @@ public class MemberController implements MemberControllerDocs {
 
         memberCommandService.resignMember(member);
         return ApiResponse.onSuccess("계정이 탈퇴되었습니다.");
+    }
+
+    @Override
+    @GetMapping("/my-home")
+    public ApiResponse<MemberResponseDTO.MyHomeUserInfoDTO> getMyHomeUserInfo(Member member) {
+
+        return ApiResponse.onSuccess(memberQueryService.getMyHomeUserInfo(member));
     }
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
@@ -3,6 +3,7 @@ package com.coredisc.presentation.controllerdocs;
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.member.MemberRequestDTO;
+import com.coredisc.presentation.dto.member.MemberResponseDTO;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,4 +21,7 @@ public interface MemberControllerDocs {
 
     @Operation(summary = "계정 탈퇴", description = "계정 탈퇴 기능입니다.")
     ApiResponse<String> resignMember(@CurrentMember Member member);
+
+    @Operation(summary = "마이홈 사용자 정보 확인", description = "마이홈 사용자 정보 확인 기능입니다.")
+    ApiResponse<MemberResponseDTO.MyHomeUserInfoDTO> getMyHomeUserInfo(@CurrentMember Member member);
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
@@ -6,8 +6,10 @@ import com.coredisc.presentation.dto.member.MemberRequestDTO;
 import com.coredisc.presentation.dto.member.MemberResponseDTO;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Member", description = "멤버 관련 API")
@@ -22,6 +24,10 @@ public interface MemberControllerDocs {
     @Operation(summary = "계정 탈퇴", description = "계정 탈퇴 기능입니다.")
     ApiResponse<String> resignMember(@CurrentMember Member member);
 
-    @Operation(summary = "마이홈 사용자 정보 확인", description = "마이홈 사용자 정보 확인 기능입니다.")
-    ApiResponse<MemberResponseDTO.MyHomeUserInfoDTO> getMyHomeUserInfo(@CurrentMember Member member);
+    @Operation(summary = "마이홈 사용자 본인 정보 확인", description = "마이홈 사용자 본인 정보 확인 기능입니다.")
+    ApiResponse<MemberResponseDTO.MyHomeInfoOfMeDTO> getMyHomeInfoOfMe(@CurrentMember Member member);
+
+    @Operation(summary = "마이홈 타사용자 정보 확인", description = "마이홈 타사용자 정보 확인 기능입니다.")
+    @Parameter(name = "targetUsername", description = "타사용자의 username(로그인 아이디)")
+    ApiResponse<MemberResponseDTO.MyHomeInfoOfOtherDTO> getMyHomeInfoOfOther(@CurrentMember Member member, @PathVariable String targetUsername);
 }

--- a/src/main/java/com/coredisc/presentation/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/member/MemberResponseDTO.java
@@ -1,0 +1,32 @@
+package com.coredisc.presentation.dto.member;
+
+import com.coredisc.presentation.dto.profileImg.ProfileImgResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MyHomeUserInfoDTO {
+
+        private Long memberId;
+
+        private String nickname;
+
+        private String joinDate;
+
+        private Long followerCount;
+
+        private Long followingCount;
+
+        // TODO: 총 디스크 수
+//        private Integer discCount;
+
+        private ProfileImgResponseDTO.ProfileImgDTO profileImgDTO;
+    }
+}

--- a/src/main/java/com/coredisc/presentation/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/member/MemberResponseDTO.java
@@ -24,8 +24,7 @@ public class MemberResponseDTO {
 
         private Long followingCount;
 
-        // TODO: 총 디스크 수
-//        private Integer discCount;
+        private Long discCount;
 
         private ProfileImgResponseDTO.ProfileImgDTO profileImgDTO;
     }
@@ -46,8 +45,7 @@ public class MemberResponseDTO {
 
         private Long followingCount;
 
-        // TODO: 총 디스크 수
-//        private Integer discCount;
+        private Long discCount;
 
         private Boolean isFollowing;
 

--- a/src/main/java/com/coredisc/presentation/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/member/MemberResponseDTO.java
@@ -12,7 +12,7 @@ public class MemberResponseDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class MyHomeUserInfoDTO {
+    public static class MyHomeInfoOfMeDTO {
 
         private Long memberId;
 
@@ -26,6 +26,30 @@ public class MemberResponseDTO {
 
         // TODO: 총 디스크 수
 //        private Integer discCount;
+
+        private ProfileImgResponseDTO.ProfileImgDTO profileImgDTO;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MyHomeInfoOfOtherDTO {
+
+        private Long memberId;
+
+        private String nickname;
+
+        private String joinDate;
+
+        private Long followerCount;
+
+        private Long followingCount;
+
+        // TODO: 총 디스크 수
+//        private Integer discCount;
+
+        private Boolean isFollowing;
 
         private ProfileImgResponseDTO.ProfileImgDTO profileImgDTO;
     }

--- a/src/main/java/com/coredisc/presentation/dto/profileImg/ProfileImgResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/profileImg/ProfileImgResponseDTO.java
@@ -1,0 +1,20 @@
+package com.coredisc.presentation.dto.profileImg;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ProfileImgResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfileImgDTO {
+
+        private Long profileImgId;
+
+        private String imageUrl;
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용 요약

- 마이홈(본인) 정보 확인 API 구현
- 마이홈(타사용자) 정보 확인 API 구현
- 회원가입 시 기본 프로필 이미지를 적용하도록 회원가입 로직 수정

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #27 

## 📎 기타 참고사항
- 7월 13일 마이홈 커밋부터 확인해주시면 됩니다. (그 이전 거는 아직 머지 안 된 PR 커밋 히스토리)
   -Feat: 마이홈 사용자정보 조회 관련 엔티티 작성 ([56e865a](https://github.com/CoreDisc/CoreDisc-BE/pull/28/commits/56e865aa5234cc5a55ef82631b41189f2f1a314c))
