### PR TITLE
Feat: 사용자가 작성한 커스텀 질문 공유하기 API 구현

### DIFF
--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandService.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandService.java
@@ -1,5 +1,6 @@
 package com.coredisc.application.service.question;
 
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.personalQuestion.PersonalQuestion;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.question.QuestionRequestDTO;
@@ -8,4 +9,7 @@ public interface QuestionCommandService {
 
     // 내가 작성한 질문 저장
     PersonalQuestion savePersonalQuestion(QuestionRequestDTO.SavePersonalQuestionDTO request, Member member);
+
+    // 내가 작성한 질문 공유
+    OfficialQuestion saveOfficialQuestion(QuestionRequestDTO.SaveOfficialQuestionDTO request, Member member);
 }

--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
@@ -4,10 +4,12 @@ import com.coredisc.common.apiPayload.status.ErrorStatus;
 import com.coredisc.common.converter.QuestionCategoryConverter;
 import com.coredisc.common.converter.QuestionConverter;
 import com.coredisc.common.exception.handler.QuestionHandler;
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.category.Category;
 import com.coredisc.domain.category.CategoryRepository;
 import com.coredisc.domain.mapping.questionCategory.QuestionCategory;
 import com.coredisc.domain.mapping.questionCategory.QuestionCategoryRepository;
+import com.coredisc.domain.officialQuestion.OfficialQuestionRepository;
 import com.coredisc.domain.personalQuestion.PersonalQuestion;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.personalQuestion.PersonalQuestionRepository;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuestionCommandServiceImpl implements QuestionCommandService {
 
     private final PersonalQuestionRepository personalQuestionRepository;
+    private final OfficialQuestionRepository officialQuestionRepository;
     private final CategoryRepository categoryRepository;
     private final QuestionCategoryRepository questionCategoryRepository;
 
@@ -45,5 +48,28 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
         }
 
         return newPersonalQuestion;
+    }
+
+    // 내가 작성한 질문 공유
+    @Override
+    @Transactional
+    public OfficialQuestion saveOfficialQuestion(QuestionRequestDTO.SaveOfficialQuestionDTO request, Member member){
+
+        OfficialQuestion newOfficialQuestion = officialQuestionRepository.save(
+                QuestionConverter.toOfficialQuestion(request, member)
+        );
+
+        if (request.getCategoryIdList() != null) {
+            for (Long categoryId : request.getCategoryIdList()) {
+                Category category = categoryRepository.findById(categoryId)
+                        .orElseThrow(() -> new QuestionHandler(ErrorStatus.CATEGORY_NOT_FOUND));
+
+                QuestionCategory questionCategory = QuestionCategoryConverter.toQuestionCategoryByOfficialQuestion(category, newOfficialQuestion);
+
+                questionCategoryRepository.save(questionCategory);
+            }
+        }
+
+        return newOfficialQuestion;
     }
 }

--- a/src/main/java/com/coredisc/common/converter/QuestionCategoryConverter.java
+++ b/src/main/java/com/coredisc/common/converter/QuestionCategoryConverter.java
@@ -2,6 +2,7 @@ package com.coredisc.common.converter;
 
 import com.coredisc.domain.category.Category;
 import com.coredisc.domain.mapping.questionCategory.QuestionCategory;
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.personalQuestion.PersonalQuestion;
 
 public class QuestionCategoryConverter {
@@ -11,6 +12,14 @@ public class QuestionCategoryConverter {
         return QuestionCategory.builder()
                 .category(category)
                 .personalQuestion(personalQuestion)
+                .build();
+    }
+
+    public static QuestionCategory toQuestionCategoryByOfficialQuestion(Category category, OfficialQuestion officialQuestion) {
+
+        return QuestionCategory.builder()
+                .category(category)
+                .officialQuestion(officialQuestion)
                 .build();
     }
 }

--- a/src/main/java/com/coredisc/common/converter/QuestionConverter.java
+++ b/src/main/java/com/coredisc/common/converter/QuestionConverter.java
@@ -1,5 +1,6 @@
 package com.coredisc.common.converter;
 
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.personalQuestion.PersonalQuestion;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.question.QuestionRequestDTO;
@@ -21,6 +22,22 @@ public class QuestionConverter {
 
         return QuestionResponseDTO.savePersonalQuestionResultDTO.builder()
                 .id(personalQuestion.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static OfficialQuestion toOfficialQuestion(QuestionRequestDTO.SaveOfficialQuestionDTO request, Member member){
+
+        return OfficialQuestion.builder()
+                .contents(request.getQuestion())
+                .member(member)
+                .build();
+    }
+
+    public static QuestionResponseDTO.saveOfficialQuestionResultDTO toSaveOfficialQuestionResultDTO(OfficialQuestion officialQuestion) {
+
+        return QuestionResponseDTO.saveOfficialQuestionResultDTO.builder()
+                .id(officialQuestion.getId())
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/com/coredisc/domain/TodayQuestion.java
+++ b/src/main/java/com/coredisc/domain/TodayQuestion.java
@@ -3,6 +3,7 @@ package com.coredisc.domain;
 import com.coredisc.domain.common.BaseEntity;
 import com.coredisc.domain.common.enums.QuestionType;
 import com.coredisc.domain.member.Member;
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.personalQuestion.PersonalQuestion;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/coredisc/domain/mapping/questionCategory/QuestionCategory.java
+++ b/src/main/java/com/coredisc/domain/mapping/questionCategory/QuestionCategory.java
@@ -1,7 +1,7 @@
 package com.coredisc.domain.mapping.questionCategory;
 
 import com.coredisc.domain.category.Category;
-import com.coredisc.domain.OfficialQuestion;
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.personalQuestion.PersonalQuestion;
 import com.coredisc.domain.common.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestion.java
+++ b/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestion.java
@@ -1,5 +1,6 @@
-package com.coredisc.domain;
+package com.coredisc.domain.officialQuestion;
 
+import com.coredisc.domain.TodayQuestion;
 import com.coredisc.domain.common.BaseEntity;
 import com.coredisc.domain.mapping.questionCategory.QuestionCategory;
 import com.coredisc.domain.member.Member;
@@ -21,9 +22,9 @@ public class OfficialQuestion extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ColumnDefault("1")     // 0: 기본질문, 1: 공유질문
     @Column(nullable = false)
-    private boolean isOfficial;
+    @Builder.Default    // false: 기본질문, true: 공유질문
+    private boolean isOfficial = true;
 
     @Column(nullable = false)
     private String contents;

--- a/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestionRepository.java
@@ -1,0 +1,7 @@
+package com.coredisc.domain.officialQuestion;
+
+
+public interface OfficialQuestionRepository {
+
+    OfficialQuestion save(OfficialQuestion officialQuestion);
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/question/JpaOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/JpaOfficialQuestionRepository.java
@@ -1,0 +1,7 @@
+package com.coredisc.infrastructure.repository.question;
+
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaOfficialQuestionRepository extends JpaRepository<OfficialQuestion, Long> {
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/question/OfficialQuestionRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/OfficialQuestionRepositoryAdapter.java
@@ -1,0 +1,18 @@
+package com.coredisc.infrastructure.repository.question;
+
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
+import com.coredisc.domain.officialQuestion.OfficialQuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OfficialQuestionRepositoryAdapter implements OfficialQuestionRepository {
+
+    private final JpaOfficialQuestionRepository jpaOfficialQuestionRepository;
+
+    @Override
+    public OfficialQuestion save(OfficialQuestion officialQuestion) {
+        return jpaOfficialQuestionRepository.save(officialQuestion);
+    }
+}

--- a/src/main/java/com/coredisc/presentation/controller/QuestionController.java
+++ b/src/main/java/com/coredisc/presentation/controller/QuestionController.java
@@ -28,4 +28,11 @@ public class QuestionController implements QuestionControllerDocs {
 
         return ApiResponse.onSuccess(QuestionConverter.toSavePersonalQuestionResultDTO(questionCommandService.savePersonalQuestion(request, member)));
     }
+
+    // 내가 작성한 질문 공유
+    @PostMapping("/official")
+    public ApiResponse<QuestionResponseDTO.saveOfficialQuestionResultDTO> saveOfficialQuestion(@CurrentMember Member member, @Valid @RequestBody QuestionRequestDTO.SaveOfficialQuestionDTO request) {
+
+        return ApiResponse.onSuccess(QuestionConverter.toSaveOfficialQuestionResultDTO(questionCommandService.saveOfficialQuestion(request, member)));
+    }
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
@@ -16,4 +16,7 @@ public interface QuestionControllerDocs {
     @Operation(summary = "내가 작성한 질문 저장하기", description = "내가 커스텀한 질문을 저장하는 기능입니다.")
     public ApiResponse<QuestionResponseDTO.savePersonalQuestionResultDTO> savePersonalQuestion(@CurrentMember Member member, @Valid @RequestBody QuestionRequestDTO.SavePersonalQuestionDTO request);
 
+    @Operation(summary = "내가 작성한 질문 공유하기", description = "내가 커스텀한 질문을 공유하는 기능입니다.")
+    public ApiResponse<QuestionResponseDTO.saveOfficialQuestionResultDTO> saveOfficialQuestion(@CurrentMember Member member, @Valid @RequestBody QuestionRequestDTO.SaveOfficialQuestionDTO request);
+
 }

--- a/src/main/java/com/coredisc/presentation/dto/question/QuestionRequestDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/question/QuestionRequestDTO.java
@@ -23,4 +23,18 @@ public class QuestionRequestDTO {
         @Schema(description = "question", example = "오늘 아침에 먹은 것은 무엇인가요?")
         String question;
     }
+
+    @Getter
+    public static class SaveOfficialQuestionDTO {
+
+        @NotNull
+        @Size(min = 1, max = 3, message = "카테고리는 최소 1개, 최대 3개까지 선택할 수 있습니다.")
+        @Schema(description = "categoryId 목록", example = "[1, 2]")
+        List<Long> categoryIdList;
+
+        @NotBlank(message = "질문 입력은 필수입니다.")
+        @Size(max = 50, message = "질문은 50자 이내로 입력해주세요.")
+        @Schema(description = "question", example = "오늘 아침에 먹은 것은 무엇인가요?")
+        String question;
+    }
 }

--- a/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
@@ -19,4 +19,15 @@ public class QuestionResponseDTO {
 
         private LocalDateTime createdAt;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class saveOfficialQuestionResultDTO {
+
+        private Long id;
+
+        private LocalDateTime createdAt;
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용 요약
사용자가 작성한 커스텀 질문 공유하기 api 구현했습니다. 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #30 

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
OfficalQuestion 엔티티에서 디폴트값을 true(공유질문)으로 수정했습니다. 
