### PR TITLE
Feat: 닉네임&아이디 변경 API 구현

### DIFF
--- a/src/main/java/com/coredisc/application/service/member/MemberCommandService.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberCommandService.java
@@ -8,8 +8,9 @@ public interface MemberCommandService {
     // 비밀번호 변경
     void resetPassword(MemberRequestDTO.ResetPasswordDTO request);
 
-    // 닉네임 변경
-    void resetNickname(Member member, MemberRequestDTO.ResetNicknameDTO request);
+    // 닉네임, 아이디 변경
+    boolean resetNicknameAndUsername(String accessToken, Member member,
+                                     MemberRequestDTO.ResetNicknameAndUsernameDTO request);
 
     // 계정 탈퇴
     void resignMember(Member member);

--- a/src/main/java/com/coredisc/application/service/member/MemberCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberCommandServiceImpl.java
@@ -2,12 +2,17 @@ package com.coredisc.application.service.member;
 
 import com.coredisc.common.apiPayload.status.ErrorStatus;
 import com.coredisc.common.exception.handler.AuthHandler;
+import com.coredisc.common.exception.handler.MemberHandler;
+import com.coredisc.common.util.RedisUtil;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.member.MemberRepository;
 import com.coredisc.presentation.dto.member.MemberRequestDTO;
+import com.coredisc.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +20,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RedisUtil redisUtil;
+    private final JwtProvider jwtProvider;
 
     @Override
     public void resetPassword(MemberRequestDTO.ResetPasswordDTO request) {
@@ -31,10 +38,42 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
-    public void resetNickname(Member member, MemberRequestDTO.ResetNicknameDTO request) {
+    public boolean resetNicknameAndUsername(String accessToken, Member member,
+                                            MemberRequestDTO.ResetNicknameAndUsernameDTO request) {
 
-        member.setNickname(request.getNewNickname());
+        boolean isUsernameChanged = false;
+
+        // 아이디 변경
+        if(!member.getUsername().equals(request.getNewUsername())) {
+            if(memberRepository.existsByUsername(request.getNewUsername())){
+                throw new MemberHandler(ErrorStatus.USERNAME_ALREADY_EXISTS);
+            }
+            member.setUsername(request.getNewUsername());
+            isUsernameChanged = true;
+        }
+
+        // 닉네임 변경
+        if(!member.getNickname().equals(request.getNewNickname())) {
+            if(memberRepository.existsByNickname(request.getNewNickname())) {
+                throw new MemberHandler(ErrorStatus.NICKNAME_ALREADY_EXISTS);
+            }
+            member.setNickname(request.getNewNickname());
+        }
+
         memberRepository.save(member);
+
+        // username 변경시 기존 accessToken 블랙리스트 저장
+        if (isUsernameChanged) {
+            if(accessToken.startsWith("Bear ")) {
+                accessToken = accessToken.substring(7);
+            }
+            redisUtil.set(accessToken, "logout");
+            redisUtil.expire(accessToken, jwtProvider.getRemainingExpiration(accessToken), TimeUnit.MILLISECONDS);
+            // RefreshToken 삭제
+            redisUtil.delete(String.valueOf(jwtProvider.getId(accessToken)));
+        }
+
+        return isUsernameChanged;
     }
 
     @Override

--- a/src/main/java/com/coredisc/domain/member/Member.java
+++ b/src/main/java/com/coredisc/domain/member/Member.java
@@ -32,6 +32,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;
 
+    @Setter
     @Column(length = 16, nullable = false, unique = true)
     private String username;
 

--- a/src/main/java/com/coredisc/presentation/controller/MemberController.java
+++ b/src/main/java/com/coredisc/presentation/controller/MemberController.java
@@ -33,12 +33,20 @@ public class MemberController implements MemberControllerDocs {
     }
 
     @Override
-    @PatchMapping("/nickname")
-    public ApiResponse<String> resetNickname(@CurrentMember Member member,
-                                             @RequestBody @Valid MemberRequestDTO.ResetNicknameDTO request) {
+    @PatchMapping("/profile")
+    public ApiResponse<String> resetNicknameAndUsername(@RequestHeader("accessToken") String accessToken,
+                                                        @CurrentMember Member member,
+                                                        @RequestBody @Valid MemberRequestDTO.ResetNicknameAndUsernameDTO request) {
 
-        memberCommandService.resetNickname(member, request);
-        return ApiResponse.onSuccess("닉네임이 성공적으로 변경되었습니다.");
+        boolean isUsernameChanged = memberCommandService.resetNicknameAndUsername(accessToken, member, request);
+
+        // username이 변경되었을 시, 토큰 재발급 요청
+        if(isUsernameChanged) {
+            return ApiResponse.onSuccess("아이디가 변경되어 인증이 만료되었습니다. 다시 로그인 해주세요.");
+        }
+
+        // nickname만 변경되었을 시
+        return ApiResponse.onSuccess("성공적으로 변경되었습니다.");
     }
 
     @Override

--- a/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Member", description = "멤버 관련 API")
@@ -21,8 +22,10 @@ public interface MemberControllerDocs {
     @Operation(summary = "비밀번호 변경", description = "비밀번호 변경 기능입니다.")
     ApiResponse<String> resetPassword(@RequestBody @Valid MemberRequestDTO.ResetPasswordDTO request);
 
-    @Operation(summary = "닉네임 변경", description = "닉네임 변경 기능입니다.")
-    ApiResponse<String> resetNickname(@CurrentMember Member member, @RequestBody @Valid MemberRequestDTO.ResetNicknameDTO request);
+    @Operation(summary = "닉네임, 아이디 변경", description = "닉네임, 아이디 변경 기능입니다.")
+    ApiResponse<String> resetNicknameAndUsername(@RequestHeader("accessToken") String accessToken,
+                                                 @CurrentMember Member member,
+                                                 @RequestBody @Valid MemberRequestDTO.ResetNicknameAndUsernameDTO request);
 
     @Operation(summary = "계정 탈퇴", description = "계정 탈퇴 기능입니다.")
     ApiResponse<String> resignMember(@CurrentMember Member member);

--- a/src/main/java/com/coredisc/presentation/dto/auth/AuthRequestDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/auth/AuthRequestDTO.java
@@ -22,8 +22,8 @@ public class AuthRequestDTO {
         @Schema(description = "name", example = "한소희")
         private String name;
 
-        @NotBlank(message = "계정명 입력은 필수입니다.")
-        @Size(max = 16, message = "계정명은 16자 이내로 입력해주세요.")
+        @NotBlank(message = "아이디 입력은 필수입니다.")
+        @Size(max = 16, message = "아이디는 16자 이내로 입력해주세요.")
         @Schema(description = "username", example = "my_coredisc")
         private String username;
 

--- a/src/main/java/com/coredisc/presentation/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/member/MemberRequestDTO.java
@@ -29,10 +29,14 @@ public class MemberRequestDTO {
     }
 
     @Getter
-    public static class ResetNicknameDTO {
+    public static class ResetNicknameAndUsernameDTO {
 
         @NotBlank(message = "변경할 닉네임 입력은 필수입니다.")
         @Size(max = 16, message = "닉네임은 16자 이내로 입력해주세요.")
         private String newNickname;
+
+        @NotBlank(message = "변경할 아이디 입력은 필수입니다.")
+        @Size(max = 16, message = "아이디는 16자 이내로 입력해주세요.")
+        private String newUsername;
     }
 }


### PR DESCRIPTION
## 💡 작업 내용 요약
기존에 개발했던 닉네임 변경 API에서 아이디도 같이 변경할 수 있도록 수정하여 개발하였습니다.

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #34 

## 📎 기타 참고사항
- PM님과 상의한 결과, 아이디가 변경됐을 시 사용자가 재로그인을 하도록 플로우를 처리합니다. (For 인증 정보 update)
   - 따라서 아이디 변경 시, 기존 accessToken은 redis에서 logout으로 저장되고  기존 refreshToken은 삭제됩니다.
