### PR TITLE
Feat: 질문 카테고리 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/coredisc/application/service/category/CategoryQueryService.java
+++ b/src/main/java/com/coredisc/application/service/category/CategoryQueryService.java
@@ -1,0 +1,11 @@
+package com.coredisc.application.service.category;
+
+
+import com.coredisc.presentation.dto.category.CategoryResponseDTO;
+
+import java.util.List;
+
+public interface CategoryQueryService {
+
+    List<CategoryResponseDTO.CategoryDTO> getCategoryList();
+}

--- a/src/main/java/com/coredisc/application/service/category/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/category/CategoryQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package com.coredisc.application.service.category;
+
+import com.coredisc.domain.category.CategoryRepository;
+import com.coredisc.presentation.dto.category.CategoryResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryQueryServiceImpl implements CategoryQueryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public List<CategoryResponseDTO.CategoryDTO> getCategoryList(){
+
+        return categoryRepository.findCategoryList();
+    }
+}

--- a/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestion.java
+++ b/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestion.java
@@ -6,7 +6,6 @@ import com.coredisc.domain.mapping.questionCategory.QuestionCategory;
 import com.coredisc.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +23,7 @@ public class OfficialQuestion extends BaseEntity {
 
     @Column(nullable = false)
     @Builder.Default    // false: 기본질문, true: 공유질문
-    private boolean isOfficial = true;
+    private boolean isShared = true;
 
     @Column(nullable = false)
     private String contents;

--- a/src/main/java/com/coredisc/infrastructure/repository/category/CategoryRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/category/CategoryRepositoryAdaptor.java
@@ -2,9 +2,12 @@ package com.coredisc.infrastructure.repository.category;
 
 import com.coredisc.domain.category.Category;
 import com.coredisc.domain.category.CategoryRepository;
+import com.coredisc.infrastructure.repository.category.qeurydsl.QueryCategoryRepository;
+import com.coredisc.presentation.dto.category.CategoryResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,9 +15,15 @@ import java.util.Optional;
 public class CategoryRepositoryAdaptor implements CategoryRepository {
 
     private final JpaCategoryRepository jpaCategoryRepository;
+    private final QueryCategoryRepository queryCategoryRepository;
 
     @Override
     public Optional<Category> findById(Long id){
         return jpaCategoryRepository.findById(id);
+    }
+
+    @Override
+    public List<CategoryResponseDTO.CategoryDTO> findCategoryList(){
+        return queryCategoryRepository.findCategoryList();
     }
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/category/qeurydsl/QueryCategoryRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/category/qeurydsl/QueryCategoryRepository.java
@@ -1,13 +1,10 @@
-package com.coredisc.domain.category;
+package com.coredisc.infrastructure.repository.category.qeurydsl;
 
 import com.coredisc.presentation.dto.category.CategoryResponseDTO;
 
 import java.util.List;
-import java.util.Optional;
 
-public interface CategoryRepository {
-
-    Optional<Category> findById(Long id);
+public interface QueryCategoryRepository {
 
     List<CategoryResponseDTO.CategoryDTO> findCategoryList();
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/category/qeurydsl/QueryCategoryRepositoryImpl.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/category/qeurydsl/QueryCategoryRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.coredisc.infrastructure.repository.category.qeurydsl;
+
+import com.coredisc.domain.category.QCategory;
+import com.coredisc.domain.mapping.questionCategory.QQuestionCategory;
+import com.coredisc.domain.officialQuestion.QOfficialQuestion;
+import com.coredisc.domain.personalQuestion.QPersonalQuestion;
+import com.coredisc.presentation.dto.category.CategoryResponseDTO;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryCategoryRepositoryImpl implements QueryCategoryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<CategoryResponseDTO.CategoryDTO> findCategoryList() {
+        QCategory qCategory = QCategory.category;
+        QQuestionCategory qQuestionCategory = QQuestionCategory.questionCategory;
+        QOfficialQuestion qOfficialQuestion = QOfficialQuestion.officialQuestion;
+        QPersonalQuestion qPersonalQuestion = QPersonalQuestion.personalQuestion;
+
+        NumberExpression<Long> conditionalCount = new CaseBuilder()
+                .when(
+                        qOfficialQuestion.isShared.eq(false)
+                                .or(qQuestionCategory.personalQuestion.isNotNull())
+                )
+                .then(1L)
+                .otherwise(0L)
+                .sum();
+
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        CategoryResponseDTO.CategoryDTO.class,
+                        qCategory.id,
+                        qCategory.name,
+                        conditionalCount
+                ))
+                .from(qCategory)
+                .leftJoin(qQuestionCategory).on(qQuestionCategory.category.eq(qCategory))
+                .leftJoin(qQuestionCategory.officialQuestion, qOfficialQuestion)
+                .leftJoin(qQuestionCategory.personalQuestion, qPersonalQuestion)
+                .groupBy(qCategory.id)
+                .fetch();
+
+    }
+}

--- a/src/main/java/com/coredisc/presentation/controller/CategoryController.java
+++ b/src/main/java/com/coredisc/presentation/controller/CategoryController.java
@@ -1,0 +1,25 @@
+package com.coredisc.presentation.controller;
+
+import com.coredisc.application.service.category.CategoryQueryService;
+import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.presentation.controllerdocs.CategoryControllerDocs;
+import com.coredisc.presentation.dto.category.CategoryResponseDTO;
+import com.coredisc.presentation.dto.question.QuestionResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/questions")
+@RequiredArgsConstructor
+public class CategoryController implements CategoryControllerDocs {
+
+    private final CategoryQueryService categoryQueryService;
+
+    @GetMapping("/categories")
+    public ApiResponse<List<CategoryResponseDTO.CategoryDTO>> getCategoryList(){
+
+        return ApiResponse.onSuccess(categoryQueryService.getCategoryList());
+    }
+}

--- a/src/main/java/com/coredisc/presentation/controllerdocs/CategoryControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/CategoryControllerDocs.java
@@ -1,0 +1,16 @@
+package com.coredisc.presentation.controllerdocs;
+
+import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.presentation.dto.category.CategoryResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.List;
+
+@Tag(name = "Question", description = "질문 관련 API")
+public interface CategoryControllerDocs {
+
+    @Operation(summary = "질문 카테고리 리스트 조회", description = "질문 카테고리 리스트 조회하는 기능입니다.")
+    ApiResponse<List<CategoryResponseDTO.CategoryDTO>> getCategoryList();
+
+}

--- a/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
@@ -14,9 +14,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface QuestionControllerDocs {
 
     @Operation(summary = "내가 작성한 질문 저장하기", description = "내가 커스텀한 질문을 저장하는 기능입니다.")
-    public ApiResponse<QuestionResponseDTO.savePersonalQuestionResultDTO> savePersonalQuestion(@CurrentMember Member member, @Valid @RequestBody QuestionRequestDTO.SavePersonalQuestionDTO request);
+    ApiResponse<QuestionResponseDTO.savePersonalQuestionResultDTO> savePersonalQuestion(@CurrentMember Member member, @Valid @RequestBody QuestionRequestDTO.SavePersonalQuestionDTO request);
 
     @Operation(summary = "내가 작성한 질문 공유하기", description = "내가 커스텀한 질문을 공유하는 기능입니다.")
-    public ApiResponse<QuestionResponseDTO.saveOfficialQuestionResultDTO> saveOfficialQuestion(@CurrentMember Member member, @Valid @RequestBody QuestionRequestDTO.SaveOfficialQuestionDTO request);
+    ApiResponse<QuestionResponseDTO.saveOfficialQuestionResultDTO> saveOfficialQuestion(@CurrentMember Member member, @Valid @RequestBody QuestionRequestDTO.SaveOfficialQuestionDTO request);
 
 }

--- a/src/main/java/com/coredisc/presentation/dto/category/CategoryResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/category/CategoryResponseDTO.java
@@ -1,0 +1,24 @@
+package com.coredisc.presentation.dto.category;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class CategoryResponseDTO {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class CategoryDTO {
+
+        private Long id;
+
+        private String name;
+
+        private Long count;
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용 요약
- 회의 때 피드백을 참고하여 OfficialQuestion의 isOfficial을 isShared로 변경하였습니다.
- 질문 카테고리 목록 조회를 구현했습니다. 
  - 기본 질문 + 저장 질문 개수도 같이 반환하도록 했습니다. 

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작을 확인했는가?
- [ ] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #37

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
