### PR TITLE
feat: 타 사용자가 발행된 공유 질문 저장/삭제 API 구현

### DIFF
--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandService.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandService.java
@@ -1,5 +1,6 @@
 package com.coredisc.application.service.question;
 
+import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
 import com.coredisc.domain.todayQuestion.TodayQuestion;
 import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.personalQuestion.PersonalQuestion;
@@ -26,4 +27,7 @@ public interface QuestionCommandService {
 
     // 사용자가 작성하여 저장했던 질문 삭제
     void deletePersonalQuestion(Member member, Long questionId);
+
+    // 타사용자가 작성한 공유 질문 저장
+    MemberOfficialQuestion saveMemberOfficialQuestion(Member member, Long questionId);
 }

--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandService.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandService.java
@@ -30,4 +30,7 @@ public interface QuestionCommandService {
 
     // 타사용자가 작성한 공유 질문 저장
     MemberOfficialQuestion saveMemberOfficialQuestion(Member member, Long questionId);
+
+    // 저장헀던 공유 질문을 삭제
+    void deleteMemberOfficialQuestion(Member member, Long questionId);
 }

--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
@@ -5,6 +5,8 @@ import com.coredisc.common.converter.QuestionCategoryConverter;
 import com.coredisc.common.converter.QuestionConverter;
 import com.coredisc.common.exception.handler.QuestionHandler;
 import com.coredisc.domain.common.enums.QuestionType;
+import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
+import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestionRepository;
 import com.coredisc.domain.todayQuestion.TodayQuestion;
 import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.category.Category;
@@ -33,6 +35,7 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
     private final TodayQuestionRepository todayQuestionRepository;
     private final CategoryRepository categoryRepository;
     private final QuestionCategoryRepository questionCategoryRepository;
+    private final MemberOfficialQuestionRepository memberOfficialQuestionRepository;
 
     // 내가 작성한 질문 저장
     @Override
@@ -218,5 +221,21 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
         questionCategoryRepository.deleteByPersonalQuestion(existPersonalQuestion);
 
         personalQuestionRepository.deleteById(questionId);
+    }
+
+
+    // 타사용자가 작성한 공유 질문 저장
+    @Override
+    @Transactional
+    public MemberOfficialQuestion saveMemberOfficialQuestion(Member member, Long questionId) {
+
+        OfficialQuestion selectedOfficialQuestion = officialQuestionRepository.findById(questionId)
+                .orElseThrow(() -> new QuestionHandler(ErrorStatus.OFFICIAL_QUESTION_NOT_FOUND));
+
+        // 본인이 작성헀는지 여부
+        if (selectedOfficialQuestion.getMember().equals(member))
+            throw new QuestionHandler(ErrorStatus.CANNOT_SELECT_OWN_OFFICIAL_QUESTION);
+
+        return memberOfficialQuestionRepository.save(QuestionConverter.toMemberOfficialQuestion(member, selectedOfficialQuestion));
     }
 }

--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
@@ -238,4 +238,15 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
 
         return memberOfficialQuestionRepository.save(QuestionConverter.toMemberOfficialQuestion(member, selectedOfficialQuestion));
     }
+
+    // 저장헀던 공유 질문을 삭제
+    @Override
+    @Transactional
+    public void deleteMemberOfficialQuestion(Member member, Long questionId) {
+
+        MemberOfficialQuestion memberOfficialQuestion = memberOfficialQuestionRepository.findByMemberAndId(member, questionId)
+                .orElseThrow(() -> new QuestionHandler(ErrorStatus.MEMBER_OFFICIAL_QUESTION_NOT_FOUND));
+
+        memberOfficialQuestionRepository.delete(memberOfficialQuestion);
+    }
 }

--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
@@ -232,6 +232,10 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
         OfficialQuestion selectedOfficialQuestion = officialQuestionRepository.findById(questionId)
                 .orElseThrow(() -> new QuestionHandler(ErrorStatus.OFFICIAL_QUESTION_NOT_FOUND));
 
+        // 이미 저장 여부
+        if(memberOfficialQuestionRepository.findByMemberAndOfficialQuestion(member, selectedOfficialQuestion).isPresent())
+            throw new QuestionHandler(ErrorStatus.ALREADY_SAVED_OFFICIAL_QUESTION);
+
         // 본인이 작성헀는지 여부
         if (selectedOfficialQuestion.getMember().equals(member))
             throw new QuestionHandler(ErrorStatus.CANNOT_SELECT_OWN_OFFICIAL_QUESTION);

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -92,6 +92,7 @@ public enum ErrorStatus implements BaseErrorCode {
     DUPLICATE_RANDOM_TODAY_QUESTION_ORDER(HttpStatus.CONFLICT, "QUESTION4006", "이미 오늘 설정한 랜덤 질문이 존재합니다."),
     UNAUTHORIZED_PERSONAL_QUESTION_ACCESS(HttpStatus.FORBIDDEN, "QUESTION4007", "해당 질문에 대한 수정/삭제 권한이 없습니다."),
     PERSONAL_QUESTION_USED_IN_TODAY_QUESTION(HttpStatus.CONFLICT, "QUESTION4008", "고정 또는 랜덤 질문으로 사용된 질문은 삭제할 수 없습니다."),
+    CANNOT_SELECT_OWN_OFFICIAL_QUESTION(HttpStatus.FORBIDDEN, "QUESTION4009", "자신이 작성한 공유 질문은 저장할 수 없습니다."),
 
     // Follow 관련 에러
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW4001", "자기 자신은 팔로우할 수 없습니다."),

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -94,6 +94,7 @@ public enum ErrorStatus implements BaseErrorCode {
     PERSONAL_QUESTION_USED_IN_TODAY_QUESTION(HttpStatus.CONFLICT, "QUESTION4008", "고정 또는 랜덤 질문으로 사용된 질문은 삭제할 수 없습니다."),
     CANNOT_SELECT_OWN_OFFICIAL_QUESTION(HttpStatus.FORBIDDEN, "QUESTION4009", "자신이 작성한 공유 질문은 저장할 수 없습니다."),
     MEMBER_OFFICIAL_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION4010", "저장한 공유 질문이 존재하지 않습니다."),
+    ALREADY_SAVED_OFFICIAL_QUESTION(HttpStatus.BAD_REQUEST, "QUESTION4011", "이미 해당 공유 질문을 저장했습니다."),
 
     // Follow 관련 에러
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW4001", "자기 자신은 팔로우할 수 없습니다."),

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -93,6 +93,7 @@ public enum ErrorStatus implements BaseErrorCode {
     UNAUTHORIZED_PERSONAL_QUESTION_ACCESS(HttpStatus.FORBIDDEN, "QUESTION4007", "해당 질문에 대한 수정/삭제 권한이 없습니다."),
     PERSONAL_QUESTION_USED_IN_TODAY_QUESTION(HttpStatus.CONFLICT, "QUESTION4008", "고정 또는 랜덤 질문으로 사용된 질문은 삭제할 수 없습니다."),
     CANNOT_SELECT_OWN_OFFICIAL_QUESTION(HttpStatus.FORBIDDEN, "QUESTION4009", "자신이 작성한 공유 질문은 저장할 수 없습니다."),
+    MEMBER_OFFICIAL_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION4010", "저장한 공유 질문이 존재하지 않습니다."),
 
     // Follow 관련 에러
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW4001", "자기 자신은 팔로우할 수 없습니다."),

--- a/src/main/java/com/coredisc/common/converter/QuestionConverter.java
+++ b/src/main/java/com/coredisc/common/converter/QuestionConverter.java
@@ -1,6 +1,7 @@
 package com.coredisc.common.converter;
 
 import com.coredisc.domain.common.enums.QuestionType;
+import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
 import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.personalQuestion.PersonalQuestion;
 import com.coredisc.domain.member.Member;
@@ -175,5 +176,21 @@ public class QuestionConverter {
                         .question(null)
                         .questionType(null)
                         .build());
+    }
+
+    public static MemberOfficialQuestion toMemberOfficialQuestion(Member member, OfficialQuestion officialQuestion){
+
+        return MemberOfficialQuestion.builder()
+                .officialQuestion(officialQuestion)
+                .member(member)
+                .build();
+    }
+
+    public static QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO toSaveMemberOfficialQuestionResultDTO(MemberOfficialQuestion memberOfficialQuestion) {
+
+        return QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO.builder()
+                .id(memberOfficialQuestion.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
     }
 }

--- a/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestion.java
+++ b/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestion.java
@@ -1,0 +1,31 @@
+package com.coredisc.domain.mapping.memberOfficialQuestion;
+
+import com.coredisc.domain.common.BaseEntity;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MemberOfficialQuestion extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)   // 즐겨찾기. false = 즐겨찾기 안함, true = 즐겨찾기 함
+    @Builder.Default
+    private Boolean isFavorite = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "official_question_id")
+    private OfficialQuestion officialQuestion;
+}

--- a/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestionRepository.java
@@ -1,6 +1,14 @@
 package com.coredisc.domain.mapping.memberOfficialQuestion;
 
+import com.coredisc.domain.member.Member;
+
+import java.util.Optional;
+
 public interface MemberOfficialQuestionRepository {
 
     MemberOfficialQuestion save(MemberOfficialQuestion memberOfficialQuestion);
+
+    Optional<MemberOfficialQuestion> findByMemberAndId(Member member, Long id);
+
+    void delete(MemberOfficialQuestion memberOfficialQuestion);
 }

--- a/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestionRepository.java
@@ -1,6 +1,7 @@
 package com.coredisc.domain.mapping.memberOfficialQuestion;
 
 import com.coredisc.domain.member.Member;
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
 
 import java.util.Optional;
 
@@ -11,4 +12,7 @@ public interface MemberOfficialQuestionRepository {
     Optional<MemberOfficialQuestion> findByMemberAndId(Member member, Long id);
 
     void delete(MemberOfficialQuestion memberOfficialQuestion);
+
+    Optional<MemberOfficialQuestion> findByMemberAndOfficialQuestion(Member member, OfficialQuestion officialQuestion);
+
 }

--- a/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestionRepository.java
@@ -1,0 +1,6 @@
+package com.coredisc.domain.mapping.memberOfficialQuestion;
+
+public interface MemberOfficialQuestionRepository {
+
+    MemberOfficialQuestion save(MemberOfficialQuestion memberOfficialQuestion);
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/question/JpaMemberOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/JpaMemberOfficialQuestionRepository.java
@@ -1,0 +1,7 @@
+package com.coredisc.infrastructure.repository.question;
+
+import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaMemberOfficialQuestionRepository extends JpaRepository<MemberOfficialQuestion, Long> {
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/question/JpaMemberOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/JpaMemberOfficialQuestionRepository.java
@@ -2,6 +2,7 @@ package com.coredisc.infrastructure.repository.question;
 
 import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
 import com.coredisc.domain.member.Member;
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +10,6 @@ import java.util.Optional;
 public interface JpaMemberOfficialQuestionRepository extends JpaRepository<MemberOfficialQuestion, Long> {
 
     Optional<MemberOfficialQuestion> findByMemberAndId(Member member, Long id);
+
+    Optional<MemberOfficialQuestion> findByMemberAndOfficialQuestion(Member member, OfficialQuestion officialQuestion);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/JpaMemberOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/JpaMemberOfficialQuestionRepository.java
@@ -1,7 +1,12 @@
 package com.coredisc.infrastructure.repository.question;
 
 import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
+import com.coredisc.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface JpaMemberOfficialQuestionRepository extends JpaRepository<MemberOfficialQuestion, Long> {
+
+    Optional<MemberOfficialQuestion> findByMemberAndId(Member member, Long id);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/MemberOfficialQuestionRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/MemberOfficialQuestionRepositoryAdapter.java
@@ -1,0 +1,18 @@
+package com.coredisc.infrastructure.repository.question;
+
+import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
+import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberOfficialQuestionRepositoryAdapter implements MemberOfficialQuestionRepository {
+
+    private final JpaMemberOfficialQuestionRepository jpaMemberOfficialQuestionRepository;
+
+    @Override
+    public MemberOfficialQuestion save(MemberOfficialQuestion memberOfficialQuestion) {
+        return jpaMemberOfficialQuestionRepository.save(memberOfficialQuestion);
+    }
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/question/MemberOfficialQuestionRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/MemberOfficialQuestionRepositoryAdapter.java
@@ -2,8 +2,11 @@ package com.coredisc.infrastructure.repository.question;
 
 import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
 import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestionRepository;
+import com.coredisc.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -15,4 +18,15 @@ public class MemberOfficialQuestionRepositoryAdapter implements MemberOfficialQu
     public MemberOfficialQuestion save(MemberOfficialQuestion memberOfficialQuestion) {
         return jpaMemberOfficialQuestionRepository.save(memberOfficialQuestion);
     }
+
+    @Override
+    public Optional<MemberOfficialQuestion> findByMemberAndId(Member member, Long id) {
+        return jpaMemberOfficialQuestionRepository.findByMemberAndId(member, id);
+    }
+
+    @Override
+    public void delete(MemberOfficialQuestion memberOfficialQuestion) {
+        jpaMemberOfficialQuestionRepository.delete(memberOfficialQuestion);
+    }
+
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/MemberOfficialQuestionRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/MemberOfficialQuestionRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.coredisc.infrastructure.repository.question;
 import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
 import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestionRepository;
 import com.coredisc.domain.member.Member;
+import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -27,6 +28,11 @@ public class MemberOfficialQuestionRepositoryAdapter implements MemberOfficialQu
     @Override
     public void delete(MemberOfficialQuestion memberOfficialQuestion) {
         jpaMemberOfficialQuestionRepository.delete(memberOfficialQuestion);
+    }
+
+    @Override
+    public Optional<MemberOfficialQuestion> findByMemberAndOfficialQuestion(Member member, OfficialQuestion officialQuestion) {
+        return jpaMemberOfficialQuestionRepository.findByMemberAndOfficialQuestion(member, officialQuestion);
     }
 
 }

--- a/src/main/java/com/coredisc/presentation/controller/QuestionController.java
+++ b/src/main/java/com/coredisc/presentation/controller/QuestionController.java
@@ -97,4 +97,11 @@ public class QuestionController implements QuestionControllerDocs {
         return ApiResponse.onSuccess("질문이 삭제되었습니다.");
     }
 
+    // 타사용자가 작성한 공유 질문 저장
+    @PostMapping("/official/{questionId}")
+    public ApiResponse<QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO> saveMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId) {
+
+        return ApiResponse.onSuccess(QuestionConverter.toSaveMemberOfficialQuestionResultDTO(questionCommandService.saveMemberOfficialQuestion(member, questionId)));
+    }
+    
 }

--- a/src/main/java/com/coredisc/presentation/controller/QuestionController.java
+++ b/src/main/java/com/coredisc/presentation/controller/QuestionController.java
@@ -103,5 +103,14 @@ public class QuestionController implements QuestionControllerDocs {
 
         return ApiResponse.onSuccess(QuestionConverter.toSaveMemberOfficialQuestionResultDTO(questionCommandService.saveMemberOfficialQuestion(member, questionId)));
     }
-    
+
+    // 저장헀던 공유 질문을 삭제
+    @DeleteMapping("/official/saved/{questionId}")
+    public ApiResponse<String> deleteMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId) {
+
+        questionCommandService.deleteMemberOfficialQuestion(member, questionId);
+
+        return ApiResponse.onSuccess("질문이 삭제되었습니다.");
+    }
+
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
@@ -74,4 +74,10 @@ public interface QuestionControllerDocs {
     })
     ApiResponse<QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO> saveMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId);
 
+    @Operation(summary = "저장했던 공유 질문 삭제", description = "타사용자가 발행하여 저장헀던 공유 질문을 삭제하는 기능입니다.")
+    @Parameters({
+            @Parameter(name = "questionId", description = "질문ID pathVariable입니다."),
+    })
+    ApiResponse<String> deleteMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId);
+
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
@@ -68,4 +68,10 @@ public interface QuestionControllerDocs {
     })
     ApiResponse<String> deletePersonalQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId);
 
+    @Operation(summary = "타사용자가 작성한 공유 질문 저장", description = "타사용자가 발행한 공유 질문을 저장하는 기능입니다.")
+    @Parameters({
+            @Parameter(name = "questionId", description = "질문ID pathVariable입니다."),
+    })
+    ApiResponse<QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO> saveMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId);
+
 }

--- a/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
@@ -127,4 +127,15 @@ public class QuestionResponseDTO {
 
         private QuestionType questionType;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class SaveMemberOfficialQuestionResultDTO {
+
+        private Long id;
+
+        private LocalDateTime createdAt;
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용 요약
- 타사용자가 발행한 공유 질문 저장하기
- 저장했던 타사용자의 공유 질문 삭제하기

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작을 확인했는가?
- [ ] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
