### PR TITLE
Feat: 캘린더 API 구현

### DIFF
--- a/src/main/java/com/coredisc/application/service/calendar/CalendarQueryService.java
+++ b/src/main/java/com/coredisc/application/service/calendar/CalendarQueryService.java
@@ -1,0 +1,10 @@
+package com.coredisc.application.service.calendar;
+
+import com.coredisc.domain.member.Member;
+import com.coredisc.presentation.dto.calendar.CalendarResponseDTO;
+
+public interface CalendarQueryService {
+
+    CalendarResponseDTO.CalendarDTO getCalendar(int year, int month, Member member);
+
+}

--- a/src/main/java/com/coredisc/application/service/calendar/CalendarQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/calendar/CalendarQueryServiceImpl.java
@@ -1,0 +1,47 @@
+package com.coredisc.application.service.calendar;
+
+import com.coredisc.common.converter.CalendarConverter;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.post.PostRepository;
+import com.coredisc.presentation.dto.calendar.CalendarPostDTO;
+import com.coredisc.presentation.dto.calendar.CalendarResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarQueryServiceImpl implements CalendarQueryService {
+    private final PostRepository postRepository;
+
+    public CalendarResponseDTO.CalendarDTO getCalendar(int year, int month, Member member){
+        LocalDate today = LocalDate.now();
+
+        List<CalendarPostDTO> posts = postRepository.findPostInfoByMemberAndMonth(year, month, member);
+
+        Map<Integer, Long> dayToPostIdMap = posts.stream()
+                .collect(Collectors.toMap(
+                        dto -> dto.getCreatedAt().getDayOfMonth(),
+                        CalendarPostDTO::getPostId
+                ));
+
+        List<CalendarResponseDTO.DayResultDTO> days = CalendarConverter.toDayResultDTO(year, month, dayToPostIdMap);
+
+        int totalDays = posts.size();
+
+        int continuesDays = 0;
+        if (year == today.getYear() && month == today.getMonthValue()) {
+            int day = today.getDayOfMonth();
+            while (day > 0 && dayToPostIdMap.containsKey(day)) {
+                continuesDays++;
+                day--;
+            }
+        }
+
+        return CalendarConverter.toCalendarDTO(year, month, days, totalDays, continuesDays);
+    }
+}

--- a/src/main/java/com/coredisc/application/service/calendar/CalendarQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/calendar/CalendarQueryServiceImpl.java
@@ -42,6 +42,6 @@ public class CalendarQueryServiceImpl implements CalendarQueryService {
             }
         }
 
-        return CalendarConverter.toCalendarDTO(year, month, days, totalDays, continuesDays);
+        return CalendarConverter.toCalendarDTO(year, month, days, totalDays, continuesDays, LocalDate.from(member.getCreatedAt()));
     }
 }

--- a/src/main/java/com/coredisc/common/converter/CalendarConverter.java
+++ b/src/main/java/com/coredisc/common/converter/CalendarConverter.java
@@ -44,9 +44,12 @@ public class CalendarConverter {
         boolean hasPrevMonth = target.isAfter(YearMonth.from(signupDate));
         boolean hasNextMonth = target.isBefore(YearMonth.now());
 
+        String startDay = target.atDay(1).getDayOfWeek().name().toLowerCase();
+
         return CalendarResponseDTO.CalendarDTO.builder()
                 .year(year)
                 .month(month)
+                .startDay(startDay)
                 .days(days)
                 .totalDays(totalDays)
                 .continuesDays(continuesDays)

--- a/src/main/java/com/coredisc/common/converter/CalendarConverter.java
+++ b/src/main/java/com/coredisc/common/converter/CalendarConverter.java
@@ -1,0 +1,57 @@
+package com.coredisc.common.converter;
+
+import com.coredisc.presentation.dto.calendar.CalendarResponseDTO;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CalendarConverter {
+
+    private CalendarConverter() {
+        // 인스턴스화 방지
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static List<CalendarResponseDTO.DayResultDTO> toDayResultDTO (int year, int month, Map<Integer, Long> dayToPostIdMap) {
+        int lastDay = YearMonth.of(year, month).lengthOfMonth();
+
+        List<CalendarResponseDTO.DayResultDTO> days = new ArrayList<>();
+        LocalDate today = LocalDate.now();
+
+        for (int day = 1; day <= lastDay; day++) {
+            boolean isToday = today.getYear() == year
+                    && today.getMonthValue() == month
+                    && today.getDayOfMonth() == day;
+
+            Long postId = dayToPostIdMap.get(day);
+
+            days.add(CalendarResponseDTO.DayResultDTO.builder()
+                    .day(day)
+                    .isRecorded(postId != null)
+                    .isToday(isToday)
+                    .postId(postId)
+                    .build());
+        }
+
+        return days;
+    }
+
+    public static CalendarResponseDTO.CalendarDTO toCalendarDTO(int year, int month, List<CalendarResponseDTO.DayResultDTO> days, int totalDays, int continuesDays) {
+        YearMonth target = YearMonth.of(year, month);
+        boolean hasPrevMonth = target.isAfter(YearMonth.of(2020, 1));
+        boolean hasNextMonth = target.isBefore(YearMonth.now().plusMonths(12));
+
+        return CalendarResponseDTO.CalendarDTO.builder()
+                .year(year)
+                .month(month)
+                .days(days)
+                .totalDays(totalDays)
+                .continuesDays(continuesDays)
+                .hasPrevMonth(hasPrevMonth)
+                .hasNextMonth(hasNextMonth)
+                .build();
+    }
+}

--- a/src/main/java/com/coredisc/common/converter/CalendarConverter.java
+++ b/src/main/java/com/coredisc/common/converter/CalendarConverter.java
@@ -39,10 +39,10 @@ public class CalendarConverter {
         return days;
     }
 
-    public static CalendarResponseDTO.CalendarDTO toCalendarDTO(int year, int month, List<CalendarResponseDTO.DayResultDTO> days, int totalDays, int continuesDays) {
+    public static CalendarResponseDTO.CalendarDTO toCalendarDTO(int year, int month, List<CalendarResponseDTO.DayResultDTO> days, int totalDays, int continuesDays, LocalDate signupDate) {
         YearMonth target = YearMonth.of(year, month);
-        boolean hasPrevMonth = target.isAfter(YearMonth.of(2020, 1));
-        boolean hasNextMonth = target.isBefore(YearMonth.now().plusMonths(12));
+        boolean hasPrevMonth = target.isAfter(YearMonth.from(signupDate));
+        boolean hasNextMonth = target.isBefore(YearMonth.now());
 
         return CalendarResponseDTO.CalendarDTO.builder()
                 .year(year)

--- a/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
+++ b/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
@@ -44,8 +44,8 @@ public class ReportStatConverter {
     }
 
     public static ReportStatResponseDTO.MostSelectedQuestionDTO toMostSelectedQuestionDTO(ReportRawData.MostSelectedQuestionRawData rawData) {
-        List<ReportStatResponseDTO.SeletedQuestionDTO> questions = rawData.getQuestions().stream()
-                .map(data -> ReportStatResponseDTO.SeletedQuestionDTO.builder()
+        List<ReportStatResponseDTO.SelectedQuestionDTO> questions = rawData.getQuestions().stream()
+                .map(data -> ReportStatResponseDTO.SelectedQuestionDTO.builder()
                         .questionContent(data.getQuestionContent())
                         .selectedCount(data.getSelectionCount())
                         .build()

--- a/src/main/java/com/coredisc/domain/post/PostRepository.java
+++ b/src/main/java/com/coredisc/domain/post/PostRepository.java
@@ -2,6 +2,7 @@ package com.coredisc.domain.post;
 
 import com.coredisc.domain.common.enums.PublicityType;
 import com.coredisc.domain.member.Member;
+import com.coredisc.presentation.dto.calendar.CalendarPostDTO;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -19,4 +20,6 @@ public interface PostRepository {
     List<Post> findMyPostsWithAnswers(Member member, Long cursorId, Pageable pageable);
     List<Post> findUserPostsWithAnswers(Member member, boolean isCircle, Long cursorId, Pageable pageable);
     boolean existsByMemberAndIdLessThan(Member member, Long id, Set<PublicityType> allowTypes);
+
+    List<CalendarPostDTO> findPostInfoByMemberAndMonth(int year, int month, Member member);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/post/PostRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/post/PostRepositoryAdaptor.java
@@ -6,6 +6,7 @@ import com.coredisc.domain.member.Member;
 import com.coredisc.domain.post.Post;
 import com.coredisc.domain.post.PostRepository;
 import com.coredisc.infrastructure.repository.post.queryDsl.QueryPostRepository;
+import com.coredisc.presentation.dto.calendar.CalendarPostDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -57,4 +58,10 @@ public class PostRepositoryAdaptor implements PostRepository {
         return queryPostRepository.existsByMemberAndIdLessThan(member, id, allowTypes);
     }
 
+
+
+    @Override
+    public List<CalendarPostDTO> findPostInfoByMemberAndMonth(int year, int month, Member member){
+        return queryPostRepository.findPostInfoByMemberAndMonth(year, month, member);
+    }
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/post/queryDsl/QueryPostRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/post/queryDsl/QueryPostRepository.java
@@ -3,6 +3,7 @@ package com.coredisc.infrastructure.repository.post.queryDsl;
 import com.coredisc.domain.common.enums.PublicityType;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.post.Post;
+import com.coredisc.presentation.dto.calendar.CalendarPostDTO;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -15,4 +16,8 @@ public interface QueryPostRepository {
     List<Post> findUserPostsWithAnswers(Member member, boolean isCircle, Long cursorId, Pageable pageable);
 
     boolean existsByMemberAndIdLessThan(Member member, Long id, Set<PublicityType> allowTypes);
+
+
+
+    List<CalendarPostDTO> findPostInfoByMemberAndMonth(int year, int month, Member member);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/post/queryDsl/QueryPostRepositoryImpl.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/post/queryDsl/QueryPostRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.coredisc.infrastructure.repository.post.queryDsl;
 
+import com.coredisc.common.util.DateUtil;
 import com.coredisc.domain.common.enums.PostStatus;
 import com.coredisc.domain.common.enums.PublicityType;
 import com.coredisc.domain.member.Member;
@@ -7,11 +8,15 @@ import com.coredisc.domain.post.Post;
 import com.coredisc.domain.post.QPost;
 import com.coredisc.domain.post.QPostAnswer;
 import com.coredisc.domain.post.QPostAnswerImage;
+import com.coredisc.presentation.dto.calendar.CalendarPostDTO;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Set;
 
@@ -83,5 +88,34 @@ public class QueryPostRepositoryImpl implements  QueryPostRepository{
                 )
                 .fetchFirst();
         return fetchOne != null;
+    }
+
+
+
+
+
+
+    // 캘린더 기능에 사용하기 위한 메소드 추가
+    @Override
+    public List<CalendarPostDTO> findPostInfoByMemberAndMonth(int year, int month, Member member) {
+        QPost p = QPost.post;
+
+        LocalDate start = DateUtil.getStartDate(year, month);
+        LocalDate end = DateUtil.getEndDate(year, month);
+
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        CalendarPostDTO.class,
+                        p.id,
+                        p.createdAt
+                ))
+                .from(p)
+                .where(
+                        p.member.eq(member),
+                        p.status.ne(PostStatus.TEMP),
+                        p.createdAt.between(start.atStartOfDay(), end.atTime(LocalTime.MAX))
+                )
+                .orderBy(p.createdAt.asc())
+                .fetch();
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/CalendarController.java
+++ b/src/main/java/com/coredisc/presentation/controller/CalendarController.java
@@ -1,0 +1,26 @@
+package com.coredisc.presentation.controller;
+
+import com.coredisc.application.service.calendar.CalendarQueryService;
+import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.domain.member.Member;
+import com.coredisc.presentation.controllerdocs.CalendarControllerDocs;
+import com.coredisc.presentation.dto.calendar.CalendarResponseDTO;
+import com.coredisc.security.jwt.annotaion.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reports/calendar")
+public class CalendarController implements CalendarControllerDocs {
+
+    private final CalendarQueryService calendarQueryService;
+
+    // 캘린더 조회
+    @GetMapping
+    public ApiResponse<CalendarResponseDTO.CalendarDTO> getCalendar(int year, int month, @CurrentMember Member member) {
+        return ApiResponse.onSuccess(calendarQueryService.getCalendar(year, month, member));
+    }
+}

--- a/src/main/java/com/coredisc/presentation/controllerdocs/CalendarControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/CalendarControllerDocs.java
@@ -1,0 +1,21 @@
+package com.coredisc.presentation.controllerdocs;
+
+import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.domain.member.Member;
+import com.coredisc.presentation.dto.calendar.CalendarResponseDTO;
+import com.coredisc.security.jwt.annotaion.CurrentMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Calendar", description = "캘린더 관련 API")
+public interface CalendarControllerDocs {
+
+    @Operation(summary = "월간 답변 기록 캘린더 조회", description = "사용자의 한 달 간의 답변 작성 여부와 연속 답변 일수를 조회합니다.")
+    ApiResponse<CalendarResponseDTO.CalendarDTO> getCalendar(
+            @RequestParam("year") int year,
+            @RequestParam("month") int month,
+            @Parameter(hidden = true) @CurrentMember Member member
+    );
+}

--- a/src/main/java/com/coredisc/presentation/controllerdocs/DiscControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/DiscControllerDocs.java
@@ -8,9 +8,11 @@ import com.coredisc.security.jwt.annotaion.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Tag(name = "Disc", description = "디스크 관련 API")
 public interface DiscControllerDocs {
 
     @Operation(summary = "디스크 목록 조회", description = "사용자의 월간 디스크 목록을 조회합니다.")

--- a/src/main/java/com/coredisc/presentation/dto/calendar/CalendarPostDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/calendar/CalendarPostDTO.java
@@ -1,0 +1,13 @@
+package com.coredisc.presentation.dto.calendar;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CalendarPostDTO {
+    private Long postId;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/coredisc/presentation/dto/calendar/CalendarResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/calendar/CalendarResponseDTO.java
@@ -16,6 +16,8 @@ public class CalendarResponseDTO {
     public static class CalendarDTO {
         private int year;
         private int month;
+        private String startDay;
+
         private List<DayResultDTO> days;
 
         private int totalDays;

--- a/src/main/java/com/coredisc/presentation/dto/calendar/CalendarResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/calendar/CalendarResponseDTO.java
@@ -1,0 +1,38 @@
+package com.coredisc.presentation.dto.calendar;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class CalendarResponseDTO {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CalendarDTO {
+        private int year;
+        private int month;
+        private List<DayResultDTO> days;
+
+        private int totalDays;
+        private int continuesDays;
+
+        private boolean hasPrevMonth;
+        private boolean hasNextMonth;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DayResultDTO{
+        private int day;
+        private boolean isRecorded;
+        private boolean isToday;
+        private Long postId;
+    }
+}

--- a/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatResponseDTO.java
@@ -27,7 +27,7 @@ public class ReportStatResponseDTO {
     public static class MostSelectedQuestionDTO{ //최다 선택한 랜덤 질문
         private int year;
         private int month;
-        private List<SeletedQuestionDTO> questions;
+        private List<SelectedQuestionDTO> questions;
     }
 
     @Builder
@@ -90,7 +90,7 @@ public class ReportStatResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class SeletedQuestionDTO{ //선택된 질문
+    public static class SelectedQuestionDTO{ //선택된 질문
         private String questionContent;
         private int selectedCount;
     }


### PR DESCRIPTION
## 💡 작업 내용 요약
사용자의 한 달 간의 답변 작성 여부 + 연속 답변 일수를 조회하는 API를 구현했습니다. 
클릭 시 게시글 화면으로 넘어가야 한다고 해서 postId 함께 반환하도록 해두었습니다. 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #25

## 📎 기타 참고사항
postRepository를 통해 포스트 정보를 조회해서 서비스 로직을 구성했습니다.
혹시 잘못 작성한 부분이나 개선할 부분이 있다면 말씀해주세요! 