### PR TITLE
친한 친구 관련 API 구현

### DIFF
--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandService.java
@@ -10,4 +10,7 @@ public interface FollowCommandService {
 
     // 언팔로우 하기
     void unfollow(Member member, Long targetId);
+
+    // 친한 친구 상태 변경
+    void updateCircleStatus(Member member, Long targetId, boolean isCircle);
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
@@ -2,6 +2,7 @@ package com.coredisc.application.service.follow;
 
 import com.coredisc.common.apiPayload.status.ErrorStatus;
 import com.coredisc.common.converter.FollowConverter;
+import com.coredisc.common.exception.handler.CircleHandler;
 import com.coredisc.common.exception.handler.FollowHandler;
 import com.coredisc.common.exception.handler.MemberHandler;
 import com.coredisc.domain.follow.Follow;
@@ -60,4 +61,24 @@ public class FollowCommandServiceImpl implements FollowCommandService {
         followRepository.delete(follow);
     }
 
+    @Override
+    public void updateCircleStatus(Member member, Long targetId, boolean isCircle) {
+
+        // 자기 자신을 친한친구로 설정하려는 경우
+        if (member.getId().equals(targetId)) {
+            throw new CircleHandler(ErrorStatus.SELF_CIRCLE_NOT_ALLOWED);
+        }
+
+        Member target = memberRepository.findById(targetId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 상대방이 나를 팔로우하고 있는지 확인
+        // 상대방이 나를 팔로우하고 있는 경우에만 isCircle 변경 가능
+        Follow follow = followRepository.findByFollowerAndFollowing(target, member);
+        if (follow == null) {
+            throw new FollowHandler(ErrorStatus.FOLLOWER_NOT_FOUND);
+        }
+
+        follow.updateCircle(isCircle);
+    }
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
@@ -62,6 +62,7 @@ public class FollowCommandServiceImpl implements FollowCommandService {
     }
 
     @Override
+    // 차단 시, Follow 관계가 삭제되기에 친친 설정 로직에서 차단 여부는 체크하지 않음
     public void updateCircleStatus(Member member, Long targetId, boolean isCircle) {
 
         // 자기 자신을 친한친구로 설정하려는 경우
@@ -72,13 +73,19 @@ public class FollowCommandServiceImpl implements FollowCommandService {
         Member target = memberRepository.findById(targetId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        // 상대방이 나를 팔로우하고 있는지 확인
-        // 상대방이 나를 팔로우하고 있는 경우에만 isCircle 변경 가능
-        Follow follow = followRepository.findByFollowerAndFollowing(target, member);
-        if (follow == null) {
-            throw new FollowHandler(ErrorStatus.FOLLOWER_NOT_FOUND);
+        // 상대방이 나를 팔로우 하고 있는지 확인
+        Follow followFromTarget = followRepository.findByFollowerAndFollowing(target, member);
+        if (followFromTarget == null) {
+            throw new FollowHandler(ErrorStatus.MUST_BE_MUTUAL_FOLLOW_TO_BE_CIRCLE);
         }
 
-        follow.updateCircle(isCircle);
+        // 나도 상대방을 팔로우 하고 있는지 확인 (맞팔인 경우에만 친친 가능)
+        Follow followToTarget = followRepository.findByFollowerAndFollowing(member, target);
+        if (followToTarget == null) {
+            throw new FollowHandler(ErrorStatus.MUST_BE_MUTUAL_FOLLOW_TO_BE_CIRCLE);
+        }
+
+        // 나를 팔로우 하고 있는 팔로워 중에서 친한친구 설정 가능
+        followFromTarget.updateCircle(isCircle);
     }
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
@@ -3,6 +3,7 @@ package com.coredisc.application.service.follow;
 import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -13,5 +14,8 @@ public interface FollowQueryService {
 
     // 팔로잉 목록 조회
     List<Follow> getFollowings(Member member);
+
+    // 친한 친구 목록 조회
+    FollowResponseDTO.FollowerListDTO getCircleFollowers(Member member, Long cursorId, Pageable pageable);
 
 }

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
@@ -1,12 +1,9 @@
 package com.coredisc.application.service.follow;
 
-import com.coredisc.common.apiPayload.status.ErrorStatus;
 import com.coredisc.common.converter.FollowConverter;
-import com.coredisc.common.exception.handler.MemberHandler;
 import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.follow.FollowRepository;
 import com.coredisc.domain.member.Member;
-import com.coredisc.domain.member.MemberRepository;
 import com.coredisc.infrastructure.repository.follow.queryDSL.QueryFollowRepository;
 import com.coredisc.presentation.dto.cursor.CursorDTO;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
@@ -7,17 +7,22 @@ import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.follow.FollowRepository;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.member.MemberRepository;
+import com.coredisc.infrastructure.repository.follow.queryDSL.QueryFollowRepository;
+import com.coredisc.presentation.dto.cursor.CursorDTO;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class FollowQueryServiceImpl implements FollowQueryService {
 
     private final FollowRepository followRepository;
+    private final QueryFollowRepository queryFollowRepository;
 
     @Override
     public List<Follow> getFollowers(Member member) {
@@ -29,5 +34,26 @@ public class FollowQueryServiceImpl implements FollowQueryService {
     public List<Follow> getFollowings(Member member) {
 
         return followRepository.findAllByFollower(member);
+    }
+
+    @Override
+    public FollowResponseDTO.FollowerListDTO getCircleFollowers(Member member, Long cursorId, Pageable pageable) {
+
+        List<Follow> result = queryFollowRepository.findCircleFollowers(member, cursorId, pageable);
+
+        boolean hasNext = result.size() > pageable.getPageSize();
+        if (hasNext) result.remove(pageable.getPageSize());
+
+        List<FollowResponseDTO.FollowerDTO> dtos = result.stream()
+                .map(FollowConverter::toFollowerDTO)
+                .collect(Collectors.toList());
+
+        CursorDTO<FollowResponseDTO.FollowerDTO> cursorDTO = new CursorDTO<>(dtos, hasNext);
+        int totalCount = queryFollowRepository.countCircleFollowers(member);
+
+        return FollowResponseDTO.FollowerListDTO.builder()
+                .totalCount(totalCount)
+                .followerCursor(cursorDTO)
+                .build();
     }
 }

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -92,7 +92,6 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "FOLLOW4002", "이미 팔로우한 이력이 있습니다."),
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW4003", "팔로우한 이력이 없습니다."),
     SELF_UNFOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW4004", "자기 자신은 언팔로우할 수 없습니다."),
-    FOLLOWER_NOT_FOUND(HttpStatus.BAD_REQUEST, "FOLLOW4005", "해당 팔로워는 존재하지 않습니다."),
 
     // 차단 관련 에러
     BLOCKED_MEMBER_REQUEST(HttpStatus.BAD_REQUEST, "Block4001", "차단된 사용자입니다."),
@@ -103,6 +102,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Circle 관련 에러
     SELF_CIRCLE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "CIRCLE4001", "자기 자신은 친한 친구로 설정할 수 없습니다."),
+    MUST_BE_MUTUAL_FOLLOW_TO_BE_CIRCLE(HttpStatus.BAD_REQUEST, "CIRCLE4002", "서로 맞팔로우 관계여야 친한친구로 등록할 수 있습니다."),
 
     // Disc 관련 에러
     DISC_NOT_FOUND(HttpStatus.NOT_FOUND, "DISC4001", "디스크가 존재하지 않습니다."),

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -92,6 +92,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "FOLLOW4002", "이미 팔로우한 이력이 있습니다."),
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW4003", "팔로우한 이력이 없습니다."),
     SELF_UNFOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW4004", "자기 자신은 언팔로우할 수 없습니다."),
+    FOLLOWER_NOT_FOUND(HttpStatus.BAD_REQUEST, "FOLLOW4005", "해당 팔로워는 존재하지 않습니다."),
 
     // 차단 관련 에러
     BLOCKED_MEMBER_REQUEST(HttpStatus.BAD_REQUEST, "Block4001", "차단된 사용자입니다."),
@@ -99,6 +100,9 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_BLOCKING(HttpStatus.BAD_REQUEST, "BLOCK4002", "이미 차단한 이력이 있습니다."),
     BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "BLOCK4003", "차단한 이력이 없습니다."),
     SELF_UNBLOCK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BLOCK4004", "자기 자신은 차단 취소 할 수 없습니다."),
+
+    // Circle 관련 에러
+    SELF_CIRCLE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "CIRCLE4001", "자기 자신은 친한 친구로 설정할 수 없습니다."),
 
     // Disc 관련 에러
     DISC_NOT_FOUND(HttpStatus.NOT_FOUND, "DISC4001", "디스크가 존재하지 않습니다."),

--- a/src/main/java/com/coredisc/common/converter/FollowConverter.java
+++ b/src/main/java/com/coredisc/common/converter/FollowConverter.java
@@ -19,15 +19,18 @@ public class FollowConverter {
                 .build();
     }
 
-    //TODO: profileImageUrl 추후 추가
+    // 팔로워, 친한 친구
     public static FollowResponseDTO.FollowerDTO toFollowerDTO(Follow follow) {
         return FollowResponseDTO.FollowerDTO.builder()
                 .followerId(follow.getFollower().getId())
-                .followerNickname(follow.getFollower().getNickname())
-                .followerUsername(follow.getFollower().getUsername())
+                .nickname(follow.getFollower().getNickname())
+                .username(follow.getFollower().getUsername())
+                //.profileImgDTO(ProfileImgConverter.toProfileImgDTO(follow.getFollower().getProfileImg()))
+                .isCircle(follow.isCircle())
                 .build();
     }
 
+    // TODO: 팔로워 목록 조회 - 수정 예정
     public static FollowResponseDTO.FollowerListViewDTO toFollowerListViewDTO(List<Follow> followers) {
         List<FollowResponseDTO.FollowerDTO> dtos = followers.stream()
                 .map(FollowConverter::toFollowerDTO)
@@ -55,7 +58,7 @@ public class FollowConverter {
                 .followingUsername(follow.getFollowing().getUsername())
                 .build();
     }
-
+    // TODO: 팔로잉 목록 조회 - 수정 예정
     public static FollowResponseDTO.FollowingListViewDTO toFollowingListViewDTO(List<Follow> followings) {
         List<FollowResponseDTO.FollowingDTO> dtos = followings.stream()
                 .map(FollowConverter::toFollowingDTO)

--- a/src/main/java/com/coredisc/common/exception/handler/CircleHandler.java
+++ b/src/main/java/com/coredisc/common/exception/handler/CircleHandler.java
@@ -1,0 +1,8 @@
+package com.coredisc.common.exception.handler;
+
+import com.coredisc.common.apiPayload.code.BaseErrorCode;
+import com.coredisc.common.exception.GeneralException;
+
+public class CircleHandler extends GeneralException {
+    public CircleHandler(BaseErrorCode code) { super(code); }
+}

--- a/src/main/java/com/coredisc/domain/follow/Follow.java
+++ b/src/main/java/com/coredisc/domain/follow/Follow.java
@@ -30,4 +30,7 @@ public class Follow extends BaseEntity {
     @Builder.Default
     private boolean isCircle = false;
 
+    public void updateCircle(boolean isCircle) {
+        this.isCircle = isCircle;
+    }
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/queryDSL/QueryFollowRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/queryDSL/QueryFollowRepository.java
@@ -1,0 +1,14 @@
+package com.coredisc.infrastructure.repository.follow.queryDSL;
+
+import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.member.Member;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface QueryFollowRepository {
+
+    List<Follow> findCircleFollowers(Member member, Long cursorId, Pageable pageable);
+
+    int countCircleFollowers(Member member);
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/queryDSL/QueryFollowRepositoryImpl.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/queryDSL/QueryFollowRepositoryImpl.java
@@ -3,14 +3,12 @@ package com.coredisc.infrastructure.repository.follow.queryDSL;
 import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.follow.QFollow;
 import com.coredisc.domain.member.Member;
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/queryDSL/QueryFollowRepositoryImpl.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/queryDSL/QueryFollowRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.coredisc.infrastructure.repository.follow.queryDSL;
+
+import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.follow.QFollow;
+import com.coredisc.domain.member.Member;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryFollowRepositoryImpl implements QueryFollowRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Follow> findCircleFollowers(Member member, Long cursorId, Pageable pageable) {
+        QFollow follow = QFollow.follow;
+
+        return queryFactory
+                .selectFrom(follow)
+                .where(
+                        follow.following.eq(member),
+                        follow.isCircle.isTrue(),
+                        cursorId != null ? follow.id.lt(cursorId) : null
+                )
+                .orderBy(follow.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    @Override
+    public int countCircleFollowers(Member member) {
+        QFollow follow = QFollow.follow;
+
+        Long count = queryFactory
+                .select(follow.count())
+                .from(follow)
+                .where(
+                        follow.following.eq(member),
+                        follow.isCircle.isTrue()
+                )
+                .fetchOne();
+
+        return count != null ? count.intValue() : 0;
+    }
+}

--- a/src/main/java/com/coredisc/presentation/controller/CircleController.java
+++ b/src/main/java/com/coredisc/presentation/controller/CircleController.java
@@ -1,11 +1,15 @@
 package com.coredisc.presentation.controller;
 
 import com.coredisc.application.service.follow.FollowCommandService;
+import com.coredisc.application.service.follow.FollowQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.controllerdocs.CircleControllerDocs;
+import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class CircleController implements CircleControllerDocs {
 
     private final FollowCommandService followCommandService;
+    private final FollowQueryService followQueryService;
 
     @PatchMapping("/api/circle/{targetId}")
     public ApiResponse<String> addToCircle(@CurrentMember Member member,
@@ -30,5 +35,15 @@ public class CircleController implements CircleControllerDocs {
         followCommandService.updateCircleStatus(member, targetId, false);
 
         return ApiResponse.onSuccess("성공적으로 친한 친구가 취소되었습니다.");
+    }
+
+    @GetMapping("/api/circles")
+    public ApiResponse<FollowResponseDTO.FollowerListDTO> getCircleFollowers(
+            @CurrentMember Member member,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false, defaultValue = "10") Integer size
+    ) {
+        Pageable pageable = PageRequest.of(0, size);
+        return ApiResponse.onSuccess(followQueryService.getCircleFollowers(member, cursorId, pageable));
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/CircleController.java
+++ b/src/main/java/com/coredisc/presentation/controller/CircleController.java
@@ -6,10 +6,7 @@ import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.controllerdocs.CircleControllerDocs;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,7 +14,7 @@ public class CircleController implements CircleControllerDocs {
 
     private final FollowCommandService followCommandService;
 
-    @PostMapping("/api/circle/{targetId}")
+    @PatchMapping("/api/circle/{targetId}")
     public ApiResponse<String> addToCircle(@CurrentMember Member member,
                                            @PathVariable Long targetId) {
 
@@ -26,7 +23,7 @@ public class CircleController implements CircleControllerDocs {
         return ApiResponse.onSuccess("성공적으로 친한 친구가 설정되었습니다.");
     }
 
-    @DeleteMapping("/api/circle/{targetId}")
+    @PatchMapping("/api/circle/{targetId}")
     public ApiResponse<String> removeToCircle(@CurrentMember Member member,
                                               @PathVariable Long targetId) {
 

--- a/src/main/java/com/coredisc/presentation/controller/CircleController.java
+++ b/src/main/java/com/coredisc/presentation/controller/CircleController.java
@@ -1,0 +1,37 @@
+package com.coredisc.presentation.controller;
+
+import com.coredisc.application.service.follow.FollowCommandService;
+import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.domain.member.Member;
+import com.coredisc.presentation.controllerdocs.CircleControllerDocs;
+import com.coredisc.security.jwt.annotaion.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CircleController implements CircleControllerDocs {
+
+    private final FollowCommandService followCommandService;
+
+    @PostMapping("/api/circle/{targetId}")
+    public ApiResponse<String> addToCircle(@CurrentMember Member member,
+                                           @PathVariable Long targetId) {
+
+        followCommandService.updateCircleStatus(member, targetId, true);
+
+        return ApiResponse.onSuccess("성공적으로 친한 친구가 설정되었습니다.");
+    }
+
+    @DeleteMapping("/api/circle/{targetId}")
+    public ApiResponse<String> removeToCircle(@CurrentMember Member member,
+                                              @PathVariable Long targetId) {
+
+        followCommandService.updateCircleStatus(member, targetId, false);
+
+        return ApiResponse.onSuccess("성공적으로 친한 친구가 취소되었습니다.");
+    }
+}

--- a/src/main/java/com/coredisc/presentation/controller/CircleController.java
+++ b/src/main/java/com/coredisc/presentation/controller/CircleController.java
@@ -19,7 +19,7 @@ public class CircleController implements CircleControllerDocs {
     private final FollowCommandService followCommandService;
     private final FollowQueryService followQueryService;
 
-    @PatchMapping("/api/circle/{targetId}")
+    @PatchMapping("/api/circle/add/{targetId}")
     public ApiResponse<String> addToCircle(@CurrentMember Member member,
                                            @PathVariable Long targetId) {
 
@@ -28,7 +28,7 @@ public class CircleController implements CircleControllerDocs {
         return ApiResponse.onSuccess("성공적으로 친한 친구가 설정되었습니다.");
     }
 
-    @PatchMapping("/api/circle/{targetId}")
+    @PatchMapping("/api/circle/remove/{targetId}")
     public ApiResponse<String> removeToCircle(@CurrentMember Member member,
                                               @PathVariable Long targetId) {
 

--- a/src/main/java/com/coredisc/presentation/controllerdocs/CircleControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/CircleControllerDocs.java
@@ -1,0 +1,18 @@
+package com.coredisc.presentation.controllerdocs;
+
+import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.domain.member.Member;
+import com.coredisc.security.jwt.annotaion.CurrentMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Circle", description = "친한 친구 관련 API")
+public interface CircleControllerDocs {
+
+    @Operation(summary = "친한 친구 설정", description = "친한 친구 설정 기능입니다.")
+    ApiResponse<String> addToCircle(@CurrentMember Member member, @PathVariable Long targetId);
+
+    @Operation(summary = "친한 친구 삭제", description = "친한 친구 삭제 기능입니다.")
+    ApiResponse<String> removeToCircle(@CurrentMember Member member, @PathVariable Long targetId);
+}

--- a/src/main/java/com/coredisc/presentation/controllerdocs/CircleControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/CircleControllerDocs.java
@@ -2,10 +2,14 @@ package com.coredisc.presentation.controllerdocs;
 
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.domain.member.Member;
+import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Circle", description = "친한 친구 관련 API")
 public interface CircleControllerDocs {
@@ -15,4 +19,13 @@ public interface CircleControllerDocs {
 
     @Operation(summary = "친한 친구 삭제", description = "친한 친구 삭제 기능입니다.")
     ApiResponse<String> removeToCircle(@CurrentMember Member member, @PathVariable Long targetId);
+
+    @Operation(summary = "친한 친구 목록 조회", description = "친한 친구 목록 조회 기능입니다. 커서 기반 페이징입니다.")
+    @Parameters({
+            @Parameter(name = "cursorId", description = "마지막으로 조회한 followId입니다. 첫 요청 때는 null, queryString입니다."),
+            @Parameter(name = "size", description = "기본값 10")
+    })
+    ApiResponse<FollowResponseDTO.FollowerListDTO> getCircleFollowers(@CurrentMember Member member,
+                                                                      @RequestParam(required = false) Long cursorId,
+                                                                      @RequestParam(required = false) Integer size);
 }

--- a/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
@@ -1,5 +1,8 @@
 package com.coredisc.presentation.dto.follow;
 
+import com.coredisc.presentation.dto.cursor.CursorDTO;
+import com.coredisc.presentation.dto.profileImg.ProfileImgResponseDTO;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,17 +17,29 @@ public class FollowResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
+    // TODO: 해당 DTO를 팔로워,친한친구 목록 조회 때 쓰는 것으로 수정할 예정
     public static class FollowerDTO {
         private Long followerId;
-        private String followerNickname;
-        private String followerUsername;
-        private String followerImageUrl;
+        private String nickname;
+        private String username;
+        private ProfileImgResponseDTO.ProfileImgDTO profileImgDTO;
+        private boolean isCircle;
     }
 
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
+    public static class FollowerListDTO {
+        private int totalCount;
+        private CursorDTO<FollowerDTO> followerCursor;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    // TODO: 팔로워 목록 조회 수정 시 삭제할 예정
     public static class FollowerListViewDTO {
         private int totalFollowerCount;
         private List<FollowerDTO> followers;
@@ -34,6 +49,7 @@ public class FollowResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
+    //TODO : 팔로잉 조회 시 isCircle 반환하지 않는 것으로 수정
     public static class FollowingDTO {
         private Long followingId;
         private String followingNickname;
@@ -46,6 +62,7 @@ public class FollowResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
+    //TODO: FollowerListDTO와 통일하기 위해 네이밍 변경 예정
     public static class FollowingListViewDTO {
         private int totalFollowingCount;
         private List<FollowingDTO> followings;

--- a/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
@@ -2,7 +2,6 @@ package com.coredisc.presentation.dto.follow;
 
 import com.coredisc.presentation.dto.cursor.CursorDTO;
 import com.coredisc.presentation.dto.profileImg.ProfileImgResponseDTO;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;


### PR DESCRIPTION
## 💡 작업 내용 요약
어떤 기능/버그/리팩토링을 했는지 요약해주세요.

친한 친구 관련 API 구현
* 친한 친구 설정
* 친한 친구 삭제
* 친한 친구 목록 조회
(친한 친구는 맞팔로우 상태에서만 가능하도록, 팔로워 중에서 설정 가능하도록 했습니다)

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #56 

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.

- 추후 수정 예정 내용
* 현재 차단하면 팔로잉만 끊기도록 되어 있는데, 팔로잉/팔로워 모두 끊기도록 수정할 예정입니다.
* 차단 관계 시, 팔로우는 불가능하도록 할 예정입니다.
* 팔로워 목록 조회 시, 친한 친구 관계인지/맞팔 관계인지 반환하도록 할 예정입니다.
