### PR TITLE
[Refactor] 팔로워/팔로잉 목록 조회&차단 로직 수정

### DIFF
--- a/src/main/java/com/coredisc/application/service/block/BlockCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/block/BlockCommandServiceImpl.java
@@ -38,10 +38,16 @@ public class BlockCommandServiceImpl implements BlockCommandService {
             throw new BlockHandler(ErrorStatus.ALREADY_BLOCKING);
         }
 
-        // 팔로우 관계였다면 팔로우 취소
-        Follow follow = followRepository.findByFollowerAndFollowing(member, target);
-        if (follow != null) {
-            followRepository.delete(follow);
+        // 팔로우 취소 : 내가 상대방을 팔로우 하고 있는 걸 끊기
+        Follow followToTarget = followRepository.findByFollowerAndFollowing(member, target);
+        if (followToTarget != null) {
+            followRepository.delete(followToTarget);
+        }
+
+        // 팔로우 취소 : 상대방이 나를 팔로우 하고 있는 걸 끊기
+        Follow followFromTarget = followRepository.findByFollowerAndFollowing(target, member);
+        if (followFromTarget != null) {
+            followRepository.delete(followFromTarget);
         }
 
         Block block = BlockConverter.toBlock(member, target);

--- a/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.coredisc.common.converter.FollowConverter;
 import com.coredisc.common.exception.handler.CircleHandler;
 import com.coredisc.common.exception.handler.FollowHandler;
 import com.coredisc.common.exception.handler.MemberHandler;
+import com.coredisc.domain.block.BlockRepository;
 import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.follow.FollowRepository;
 import com.coredisc.domain.member.Member;
@@ -20,6 +21,7 @@ public class FollowCommandServiceImpl implements FollowCommandService {
 
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
+    private final BlockRepository blockRepository;
 
     @Override
     public Follow follow(Member member, Long targetId) {
@@ -34,6 +36,11 @@ public class FollowCommandServiceImpl implements FollowCommandService {
         // 이미 팔로우한 이력이 있을 경우
         if (followRepository.existsByFollowerAndFollowing(member, target)){
             throw new FollowHandler(ErrorStatus.ALREADY_FOLLOWING);
+        }
+
+        // 차단 관계인지 확인
+        if (blockRepository.existsByBlockerAndBlocked(member, target) || blockRepository.existsByBlockerAndBlocked(target, member)) {
+            throw new FollowHandler(ErrorStatus.BLOCK_RELATIONSHIP_EXISTS);
         }
 
         Follow follow = FollowConverter.toFollow(member, target);

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryService.java
@@ -1,19 +1,16 @@
 package com.coredisc.application.service.follow;
 
-import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
-
 public interface FollowQueryService {
 
     // 팔로워 목록 조회
-    List<Follow> getFollowers(Member member);
+    FollowResponseDTO.FollowerListDTO getFollowers(Member member, Long cursorId, Pageable pageable);
 
     // 팔로잉 목록 조회
-    List<Follow> getFollowings(Member member);
+    FollowResponseDTO.FollowingListDTO getFollowings(Member member, Long cursorId, Pageable pageable);
 
     // 친한 친구 목록 조회
     FollowResponseDTO.FollowerListDTO getCircleFollowers(Member member, Long cursorId, Pageable pageable);

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
@@ -2,7 +2,6 @@ package com.coredisc.application.service.follow;
 
 import com.coredisc.common.converter.FollowConverter;
 import com.coredisc.domain.follow.Follow;
-import com.coredisc.domain.follow.FollowRepository;
 import com.coredisc.domain.member.Member;
 import com.coredisc.infrastructure.repository.follow.queryDSL.QueryFollowRepository;
 import com.coredisc.presentation.dto.cursor.CursorDTO;
@@ -18,19 +17,42 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FollowQueryServiceImpl implements FollowQueryService {
 
-    private final FollowRepository followRepository;
     private final QueryFollowRepository queryFollowRepository;
 
     @Override
-    public List<Follow> getFollowers(Member member) {
+    public FollowResponseDTO.FollowerListDTO getFollowers(Member member, Long cursorId, Pageable pageable) {
 
-        return followRepository.findAllByFollowing(member);
+        List<Follow> result = queryFollowRepository.findFollowers(member, cursorId, pageable);
+
+        boolean hasNext = result.size() > pageable.getPageSize();
+        if (hasNext) result.remove(pageable.getPageSize());
+
+        List<FollowResponseDTO.FollowerDTO> dtos = result.stream()
+                .map(FollowConverter::toFollowerDTO)
+                .collect(Collectors.toList());
+
+        CursorDTO<FollowResponseDTO.FollowerDTO> cursorDTO = new CursorDTO<>(dtos, hasNext);
+        int totalCount = queryFollowRepository.countFollowers(member);
+
+        return FollowConverter.toFollowerListDTO(totalCount, cursorDTO);
     }
 
     @Override
-    public List<Follow> getFollowings(Member member) {
+    public FollowResponseDTO.FollowingListDTO getFollowings(Member member, Long cursorId, Pageable pageable) {
 
-        return followRepository.findAllByFollower(member);
+        List<Follow> result = queryFollowRepository.findFollowings(member, cursorId, pageable);
+
+        boolean hasNext = result.size() > pageable.getPageSize();
+        if (hasNext) result.remove(pageable.getPageSize());
+
+        List<FollowResponseDTO.FollowingDTO> dtos = result.stream()
+                .map(FollowConverter::toFollowingDTO)
+                .collect(Collectors.toList());
+
+        CursorDTO<FollowResponseDTO.FollowingDTO> cursorDTO = new CursorDTO<>(dtos, hasNext);
+        int totalCount = queryFollowRepository.countFollowings(member);
+
+        return FollowConverter.toFollowingListDTO(totalCount, cursorDTO);
     }
 
     @Override

--- a/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/follow/FollowQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.coredisc.application.service.follow;
 
 import com.coredisc.common.converter.FollowConverter;
 import com.coredisc.domain.follow.Follow;
+import com.coredisc.domain.follow.FollowRepository;
 import com.coredisc.domain.member.Member;
 import com.coredisc.infrastructure.repository.follow.queryDSL.QueryFollowRepository;
 import com.coredisc.presentation.dto.cursor.CursorDTO;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 public class FollowQueryServiceImpl implements FollowQueryService {
 
     private final QueryFollowRepository queryFollowRepository;
+    private final FollowRepository followRepository;
 
     @Override
     public FollowResponseDTO.FollowerListDTO getFollowers(Member member, Long cursorId, Pageable pageable) {
@@ -28,7 +30,11 @@ public class FollowQueryServiceImpl implements FollowQueryService {
         if (hasNext) result.remove(pageable.getPageSize());
 
         List<FollowResponseDTO.FollowerDTO> dtos = result.stream()
-                .map(FollowConverter::toFollowerDTO)
+                .map(follow -> {
+                    Member follower = follow.getFollower();
+                    boolean isMutual = followRepository.existsByFollowerAndFollowing(member, follower);
+                    return FollowConverter.toFollowerDTO(follow, isMutual);
+                })
                 .collect(Collectors.toList());
 
         CursorDTO<FollowResponseDTO.FollowerDTO> cursorDTO = new CursorDTO<>(dtos, hasNext);
@@ -64,7 +70,7 @@ public class FollowQueryServiceImpl implements FollowQueryService {
         if (hasNext) result.remove(pageable.getPageSize());
 
         List<FollowResponseDTO.FollowerDTO> dtos = result.stream()
-                .map(FollowConverter::toFollowerDTO)
+                .map(follow -> FollowConverter.toFollowerDTO(follow, null))
                 .collect(Collectors.toList());
 
         CursorDTO<FollowResponseDTO.FollowerDTO> cursorDTO = new CursorDTO<>(dtos, hasNext);

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -108,6 +108,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_BLOCKING(HttpStatus.BAD_REQUEST, "BLOCK4002", "이미 차단한 이력이 있습니다."),
     BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "BLOCK4003", "차단한 이력이 없습니다."),
     SELF_UNBLOCK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BLOCK4004", "자기 자신은 차단 취소 할 수 없습니다."),
+    BLOCK_RELATIONSHIP_EXISTS(HttpStatus.BAD_REQUEST, "BLOCK4005", "차단 관계가 존재합니다."),
 
     // Circle 관련 에러
     SELF_CIRCLE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "CIRCLE4001", "자기 자신은 친한 친구로 설정할 수 없습니다."),

--- a/src/main/java/com/coredisc/common/converter/FollowConverter.java
+++ b/src/main/java/com/coredisc/common/converter/FollowConverter.java
@@ -6,8 +6,6 @@ import com.coredisc.presentation.dto.cursor.CursorDTO;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class FollowConverter {
 
@@ -31,23 +29,10 @@ public class FollowConverter {
                 .build();
     }
 
-    // TODO: 하단의 toFollowerListViewDTO 삭제 후 해당 메서드로 팔로워 목록 조회 시 사용 예정
     public static FollowResponseDTO.FollowerListDTO toFollowerListDTO(int totalCount, CursorDTO cursorDTO) {
         return FollowResponseDTO.FollowerListDTO.builder()
                 .totalCount(totalCount)
                 .followerCursor(cursorDTO)
-                .build();
-    }
-
-    // TODO: 팔로워 목록 조회 - 수정 예정
-    public static FollowResponseDTO.FollowerListViewDTO toFollowerListViewDTO(List<Follow> followers) {
-        List<FollowResponseDTO.FollowerDTO> dtos = followers.stream()
-                .map(FollowConverter::toFollowerDTO)
-                .collect(Collectors.toList());
-
-        return FollowResponseDTO.FollowerListViewDTO.builder()
-                .totalFollowerCount(followers.size())
-                .followers(dtos)
                 .build();
     }
 
@@ -63,19 +48,16 @@ public class FollowConverter {
     public static FollowResponseDTO.FollowingDTO toFollowingDTO(Follow follow) {
         return FollowResponseDTO.FollowingDTO.builder()
                 .followingId(follow.getFollowing().getId())
-                .followingNickname(follow.getFollowing().getNickname())
-                .followingUsername(follow.getFollowing().getUsername())
+                .nickname(follow.getFollowing().getNickname())
+                .username(follow.getFollowing().getUsername())
+                //.profileImgDTO(ProfileImgConverter.toProfileImgDTO(follow.getFollower().getProfileImg()))
                 .build();
     }
-    // TODO: 팔로잉 목록 조회 - 수정 예정
-    public static FollowResponseDTO.FollowingListViewDTO toFollowingListViewDTO(List<Follow> followings) {
-        List<FollowResponseDTO.FollowingDTO> dtos = followings.stream()
-                .map(FollowConverter::toFollowingDTO)
-                .collect(Collectors.toList());
 
-        return FollowResponseDTO.FollowingListViewDTO.builder()
-                .totalFollowingCount(followings.size())
-                .followings(dtos)
+    public static FollowResponseDTO.FollowingListDTO toFollowingListDTO(int totalCount, CursorDTO cursorDTO) {
+        return FollowResponseDTO.FollowingListDTO.builder()
+                .totalCount(totalCount)
+                .followingCursor(cursorDTO)
                 .build();
     }
 }

--- a/src/main/java/com/coredisc/common/converter/FollowConverter.java
+++ b/src/main/java/com/coredisc/common/converter/FollowConverter.java
@@ -19,13 +19,14 @@ public class FollowConverter {
     }
 
     // 팔로워, 친한 친구
-    public static FollowResponseDTO.FollowerDTO toFollowerDTO(Follow follow) {
+    public static FollowResponseDTO.FollowerDTO toFollowerDTO(Follow follow, Boolean isMutual) {
         return FollowResponseDTO.FollowerDTO.builder()
                 .followerId(follow.getFollower().getId())
                 .nickname(follow.getFollower().getNickname())
                 .username(follow.getFollower().getUsername())
                 //.profileImgDTO(ProfileImgConverter.toProfileImgDTO(follow.getFollower().getProfileImg()))
                 .isCircle(follow.isCircle())
+                .isMutual(isMutual)
                 .build();
     }
 

--- a/src/main/java/com/coredisc/domain/follow/FollowRepository.java
+++ b/src/main/java/com/coredisc/domain/follow/FollowRepository.java
@@ -2,8 +2,6 @@ package com.coredisc.domain.follow;
 
 import com.coredisc.domain.member.Member;
 
-import java.util.List;
-
 public interface FollowRepository {
 
     // 사용자의 팔로잉 수 구하기
@@ -18,8 +16,6 @@ public interface FollowRepository {
     Follow save(Follow follow);
     Follow findByFollowerAndFollowing(Member follower, Member following);
     void delete(Follow follow);
-    List<Follow> findAllByFollowing(Member member);
-    List<Follow> findAllByFollower(Member member);
 
     // 써클 여부
     boolean existsByFollowerAndFollowingAndIsCircle(Member follower, Member following, boolean isCircle);

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/FollowRepositoryAdaptor.java
@@ -6,8 +6,6 @@ import com.coredisc.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 @RequiredArgsConstructor
 public class FollowRepositoryAdaptor implements FollowRepository {
@@ -41,16 +39,6 @@ public class FollowRepositoryAdaptor implements FollowRepository {
     @Override
     public void delete(Follow follow) {
         jpaFollowRepository.delete(follow);
-    }
-
-    @Override
-    public List<Follow> findAllByFollowing(Member member) {
-        return jpaFollowRepository.findAllByFollowing(member);
-    }
-
-    @Override
-    public List<Follow> findAllByFollower(Member member) {
-        return jpaFollowRepository.findAllByFollower(member);
     }
 
     @Override

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/JpaFollowRepository.java
@@ -4,17 +4,12 @@ import com.coredisc.domain.follow.Follow;
 import com.coredisc.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
-
 public interface JpaFollowRepository extends JpaRepository<Follow, Long> {
 
     Long countByFollowerId(Long followerId);
     Long countByFollowingId(Long memberId);
     boolean existsByFollowerAndFollowing(Member follower, Member following);
     Follow findByFollowerAndFollowing(Member follower, Member following);
-    List<Follow> findAllByFollowing(Member member);
-    List<Follow> findAllByFollower(Member member);
     boolean existsByFollowerAndFollowingAndIsCircle(Member follower, Member following, boolean isCircle);
 
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/queryDSL/QueryFollowRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/queryDSL/QueryFollowRepository.java
@@ -9,6 +9,10 @@ import java.util.List;
 public interface QueryFollowRepository {
 
     List<Follow> findCircleFollowers(Member member, Long cursorId, Pageable pageable);
+    List<Follow> findFollowers(Member member, Long cursorId, Pageable pageable);
+    List<Follow> findFollowings(Member member, Long cursorId, Pageable pageable);
 
     int countCircleFollowers(Member member);
+    int countFollowers(Member member);
+    int countFollowings(Member member);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/follow/queryDSL/QueryFollowRepositoryImpl.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/follow/queryDSL/QueryFollowRepositoryImpl.java
@@ -33,6 +33,36 @@ public class QueryFollowRepositoryImpl implements QueryFollowRepository {
     }
 
     @Override
+    public List<Follow> findFollowers(Member member, Long cursorId, Pageable pageable) {
+        QFollow follow = QFollow.follow;
+
+        return queryFactory
+                .selectFrom(follow)
+                .where(
+                        follow.following.eq(member),
+                        cursorId != null ? follow.id.lt(cursorId) : null
+                )
+                .orderBy(follow.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    @Override
+    public List<Follow> findFollowings(Member member, Long cursorId, Pageable pageable) {
+        QFollow follow = QFollow.follow;
+
+        return queryFactory
+                .selectFrom(follow)
+                .where(
+                        follow.follower.eq(member),
+                        cursorId != null ? follow.id.lt(cursorId) : null
+                )
+                .orderBy(follow.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    @Override
     public int countCircleFollowers(Member member) {
         QFollow follow = QFollow.follow;
 
@@ -43,6 +73,32 @@ public class QueryFollowRepositoryImpl implements QueryFollowRepository {
                         follow.following.eq(member),
                         follow.isCircle.isTrue()
                 )
+                .fetchOne();
+
+        return count != null ? count.intValue() : 0;
+    }
+
+    @Override
+    public int countFollowers(Member member) {
+        QFollow follow = QFollow.follow;
+
+        Long count = queryFactory
+                .select(follow.count())
+                .from(follow)
+                .where(follow.following.eq(member))
+                .fetchOne();
+
+        return count != null ? count.intValue() : 0;
+    }
+
+    @Override
+    public int countFollowings(Member member) {
+        QFollow follow = QFollow.follow;
+
+        Long count = queryFactory
+                .select(follow.count())
+                .from(follow)
+                .where(follow.follower.eq(member))
                 .fetchOne();
 
         return count != null ? count.intValue() : 0;

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -9,6 +9,8 @@ import com.coredisc.presentation.controllerdocs.FollowControllerDocs;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -40,22 +42,22 @@ public class FollowController implements FollowControllerDocs {
     }
 
     @GetMapping("/api/followers")
-    public ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers(
-            @CurrentMember Member member
+    public ApiResponse<FollowResponseDTO.FollowerListDTO> getFollowers(
+            @CurrentMember Member member,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false, defaultValue = "10") Integer size
     ) {
-
-        return ApiResponse.onSuccess(FollowConverter.toFollowerListViewDTO(
-                followQueryService.getFollowers(member)
-        ));
+        Pageable pageable = PageRequest.of(0, size);
+        return ApiResponse.onSuccess(followQueryService.getFollowers(member, cursorId, pageable));
     }
 
     @GetMapping("/api/followings")
-    public ApiResponse<FollowResponseDTO.FollowingListViewDTO> getFollowings(
-            @CurrentMember Member member
+    public ApiResponse<FollowResponseDTO.FollowingListDTO> getFollowings(
+            @CurrentMember Member member,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false, defaultValue = "10") Integer size
     ) {
-
-        return ApiResponse.onSuccess(FollowConverter.toFollowingListViewDTO(
-                followQueryService.getFollowings(member)
-        ));
+        Pageable pageable = PageRequest.of(0, size);
+        return ApiResponse.onSuccess(followQueryService.getFollowings(member, cursorId, pageable));
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/FollowController.java
+++ b/src/main/java/com/coredisc/presentation/controller/FollowController.java
@@ -32,7 +32,7 @@ public class FollowController implements FollowControllerDocs {
     }
 
     @DeleteMapping("/api/followings/{targetId}")
-    public ApiResponse<?> unfollow(
+    public ApiResponse<String> unfollow(
             @CurrentMember Member member,
             @PathVariable Long targetId
     ) {

--- a/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/FollowControllerDocs.java
@@ -5,8 +5,11 @@ import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.follow.FollowResponseDTO;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Follow", description = "팔로우 관련 API")
 public interface FollowControllerDocs {
@@ -17,9 +20,22 @@ public interface FollowControllerDocs {
     @Operation(summary = "팔로우 취소", description = "팔로우 취소(팔로윙 삭제) 기능입니다.")
     ApiResponse<?> unfollow(@CurrentMember Member member, @PathVariable Long targetId);
 
-    @Operation(summary = "팔로워 목록 조회", description = "팔로워 목록 조회 기능입니다.")
-    ApiResponse<FollowResponseDTO.FollowerListViewDTO> getFollowers(@CurrentMember Member member);
+    //TODO: description 수정
+    @Operation(summary = "팔로워 목록 조회", description = "팔로워 목록 조회 기능입니다. 커서 기반 페이징입니다.")
+    @Parameters({
+            @Parameter(name = "cursorId", description = "마지막으로 조회한 followId입니다. 첫 요청 때는 null, queryString입니다."),
+            @Parameter(name = "size", description = "기본값 10")
+    })
+    ApiResponse<FollowResponseDTO.FollowerListDTO> getFollowers(@CurrentMember Member member,
+                                                                @RequestParam(required = false) Long cursorId,
+                                                                @RequestParam(required = false) Integer size);
 
-    @Operation(summary = "팔로잉 목록 조회", description = "팔로잉 목록 조회 기능입니다.")
-    ApiResponse<FollowResponseDTO.FollowingListViewDTO> getFollowings(@CurrentMember Member member);
+    @Operation(summary = "팔로잉 목록 조회", description = "팔로잉 목록 조회 기능입니다. 커서 기반 페이징입니다.")
+    @Parameters({
+            @Parameter(name = "cursorId", description = "마지막으로 조회한 followId입니다. 첫 요청 때는 null, queryString입니다."),
+            @Parameter(name = "size", description = "기본값 10")
+    })
+    ApiResponse<FollowResponseDTO.FollowingListDTO> getFollowings(@CurrentMember Member member,
+                                                                  @RequestParam(required = false) Long cursorId,
+                                                                  @RequestParam(required = false) Integer size);
 }

--- a/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public class FollowResponseDTO {
 
@@ -38,33 +37,20 @@ public class FollowResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    // TODO: 팔로워 목록 조회 수정 시 삭제할 예정
-    public static class FollowerListViewDTO {
-        private int totalFollowerCount;
-        private List<FollowerDTO> followers;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    //TODO : 팔로잉 조회 시 isCircle 반환하지 않는 것으로 수정
     public static class FollowingDTO {
         private Long followingId;
-        private String followingNickname;
-        private String followingUsername;
-        private String followingImageUrl;
-        private boolean isCircle;
+        private String nickname;
+        private String username;
+        private ProfileImgResponseDTO.ProfileImgDTO profileImgDTO;
     }
 
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    //TODO: FollowerListDTO와 통일하기 위해 네이밍 변경 예정
-    public static class FollowingListViewDTO {
-        private int totalFollowingCount;
-        private List<FollowingDTO> followings;
+    public static class FollowingListDTO {
+        private int totalCount;
+        private CursorDTO<FollowingDTO> followingCursor;
     }
 
     @Getter

--- a/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/follow/FollowResponseDTO.java
@@ -2,6 +2,7 @@ package com.coredisc.presentation.dto.follow;
 
 import com.coredisc.presentation.dto.cursor.CursorDTO;
 import com.coredisc.presentation.dto.profileImg.ProfileImgResponseDTO;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,13 +16,15 @@ public class FollowResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    // TODO: 해당 DTO를 팔로워,친한친구 목록 조회 때 쓰는 것으로 수정할 예정
     public static class FollowerDTO {
         private Long followerId;
         private String nickname;
         private String username;
         private ProfileImgResponseDTO.ProfileImgDTO profileImgDTO;
         private boolean isCircle;
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private Boolean isMutual;
     }
 
     @Getter


### PR DESCRIPTION
## 💡 작업 내용 요약
어떤 기능/버그/리팩토링을 했는지 요약해주세요.

* 차단 시, 팔로워도 끊기도록 수정
* 차단 관계 시, 팔로우 불가능하도록 수정
* 팔로워 목록 조회 시, 친한친구 여부/맞팔로우 여부도 함께 반환하도록 수정
* 팔로워/팔로잉 목록 조회 시, 커서 기반 페이징 방식으로 응답 구조 수정

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #76 

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
