### PR TITLE
Feat: 마이홈(본인/타사용자) 사용자 정보 조회 API 수정

### DIFF
--- a/src/main/java/com/coredisc/application/service/member/MemberQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberQueryServiceImpl.java
@@ -9,6 +9,7 @@ import com.coredisc.common.util.DateUtil;
 import com.coredisc.common.util.FormatNumberUtil;
 import com.coredisc.domain.block.BlockRepository;
 import com.coredisc.domain.common.enums.AnswerType;
+import com.coredisc.domain.common.enums.PostStatus;
 import com.coredisc.domain.common.enums.PublicityType;
 import com.coredisc.domain.disc.DiscRepository;
 import com.coredisc.domain.follow.FollowRepository;
@@ -26,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -61,15 +63,15 @@ public class MemberQueryServiceImpl implements MemberQueryService {
                 followRepository.countByFollowerId(member.getId())
         );
 
-        // 총 디스크 수(월별 리포트 수)
-        String discCount = FormatNumberUtil.formatNumberUnit(
-                discRepository.countByMember(member)
+        // 총 게시글 수 (PUBLISHED인 것만)
+        String postCount = FormatNumberUtil.formatNumberUnit(
+                postRepository.countByMemberAndStatus(member, PostStatus.PUBLISHED)
         );
 
         // 사용자의 프로필 이미지
         ProfileImg profileImg = profileImgRepository.findByMember(member);
 
-        return MemberConverter.toMyHomeInfoDTO(member, followerCount, followingCount, discCount, profileImg);
+        return MemberConverter.toMyHomeInfoDTO(member, followerCount, followingCount, postCount, profileImg);
     }
 
     @Override
@@ -94,12 +96,6 @@ public class MemberQueryServiceImpl implements MemberQueryService {
                 followRepository.countByFollowerId(targetMember.getId())
         );
 
-        // 총 디스크 수(월별 리포트 수)
-        String discCount = FormatNumberUtil.formatNumberUnit(
-                discRepository.countByMember(targetMember)
-        );
-
-
         // 타사용자의 프로필 이미지
         ProfileImg profileImg = profileImgRepository.findByMember(targetMember);
 
@@ -109,9 +105,25 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         // 차단 여부
         boolean isBlocked = blockRepository.existsByBlockerAndBlocked(member, targetMember);
 
+        // Member가 targetMember의 Circle인지 여부
+        boolean isCircle = followRepository.existsByFollowerAndFollowingAndIsCircle(targetMember, member, true);
+
+        List<PublicityType> visibleTypes;
+        if (!isCircle) {
+            // Circle이 아니면 총 게시글 수 == PUBLISHED면서 OFFICIAL
+            visibleTypes = List.of(PublicityType.OFFICIAL);
+        } else {
+            // Circle이면 총 게시글 수 == PUBLISHED면서 OFFICIAL + CIRCLE
+            visibleTypes = Arrays.asList(PublicityType.OFFICIAL, PublicityType.CIRCLE);
+        }
+
+        String postCount = FormatNumberUtil.formatNumberUnit(
+                postRepository.countByMemberAndStatusAndPublicityIn(targetMember, PostStatus.PUBLISHED, visibleTypes)
+        );
+
         return MemberConverter.toUserHomeInfoDTO(
                 targetMember, followerCount, followingCount,
-                discCount, profileImg, isFollowing, isBlocked
+                postCount, profileImg, isFollowing, isBlocked
         );
     }
 

--- a/src/main/java/com/coredisc/common/converter/MemberConverter.java
+++ b/src/main/java/com/coredisc/common/converter/MemberConverter.java
@@ -90,7 +90,7 @@ public class MemberConverter {
     }
 
     public static MemberResponseDTO.MyHomeInfoDTO toMyHomeInfoDTO(Member member, String followerCount,
-                                                                  String followingCount, String discCount,
+                                                                  String followingCount, String postCount,
                                                                   ProfileImg profileImg) {
 
         return MemberResponseDTO.MyHomeInfoDTO.builder()
@@ -99,13 +99,13 @@ public class MemberConverter {
                 .nickname(member.getNickname())
                 .followerCount(followerCount)
                 .followingCount(followingCount)
-                .discCount(discCount)
+                .postCount(postCount)
                 .profileImgDTO(ProfileImgConverter.toProfileImgDTO(profileImg))
                 .build();
     }
 
     public static MemberResponseDTO.UserHomeInfoDTO toUserHomeInfoDTO(Member targetMember, String followerCount,
-                                                                      String followingCount, String discCount,
+                                                                      String followingCount, String postCount,
                                                                       ProfileImg profileImg, boolean isFollowing,
                                                                       boolean isBlocked) {
 
@@ -115,7 +115,7 @@ public class MemberConverter {
                 .nickname(targetMember.getNickname())
                 .followerCount(followerCount)
                 .followingCount(followingCount)
-                .discCount(discCount)
+                .postCount(postCount)
                 .isFollowing(isFollowing)
                 .isBlocked(isBlocked)
                 .profileImgDTO(ProfileImgConverter.toProfileImgDTO(profileImg))

--- a/src/main/java/com/coredisc/domain/post/PostRepository.java
+++ b/src/main/java/com/coredisc/domain/post/PostRepository.java
@@ -1,6 +1,7 @@
 package com.coredisc.domain.post;
 
 import com.coredisc.domain.common.enums.FeedType;
+import com.coredisc.domain.common.enums.PostStatus;
 import com.coredisc.domain.common.enums.PublicityType;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.calendar.CalendarPostDTO;
@@ -18,6 +19,9 @@ public interface PostRepository {
     Optional<Post> findById(Long id);
     void delete(Post post);
     void deleteById(Long id);
+    long countByMemberAndStatus(Member member, PostStatus status);
+    long countByMemberAndStatusAndPublicityIn(Member member, PostStatus status, List<PublicityType> publicityTypes);
+
 
     // QueryDSL
     List<Post> findMyPostsWithAnswers(Member member, Long cursorId, Pageable pageable);

--- a/src/main/java/com/coredisc/infrastructure/repository/post/JpaPostRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/post/JpaPostRepository.java
@@ -1,15 +1,18 @@
 package com.coredisc.infrastructure.repository.post;
 
 
-import com.coredisc.domain.member.QMember;
+import com.coredisc.domain.common.enums.PostStatus;
+import com.coredisc.domain.common.enums.PublicityType;
+import com.coredisc.domain.member.Member;
 import com.coredisc.domain.post.Post;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface JpaPostRepository extends JpaRepository<Post, Long> {
 
+    long countByMemberAndStatus(Member member, PostStatus status);
+    long countByMemberAndStatusAndPublicityIn(Member member, PostStatus status, List<PublicityType> publicityTypes);
 }
 
 

--- a/src/main/java/com/coredisc/infrastructure/repository/post/PostRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/post/PostRepositoryAdaptor.java
@@ -2,14 +2,15 @@ package com.coredisc.infrastructure.repository.post;
 
 
 import com.coredisc.domain.common.enums.FeedType;
+import com.coredisc.domain.common.enums.PostStatus;
 import com.coredisc.domain.common.enums.PublicityType;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.post.Post;
 import com.coredisc.domain.post.PostAnswer;
 import com.coredisc.domain.post.PostRepository;
 import com.coredisc.infrastructure.repository.post.queryDsl.QueryPostRepository;
-import com.coredisc.presentation.dto.post.PostResponseDTO;
 import com.coredisc.presentation.dto.calendar.CalendarPostDTO;
+import com.coredisc.presentation.dto.post.PostResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -45,6 +46,16 @@ public class PostRepositoryAdaptor implements PostRepository {
     @Override
     public void deleteById(Long id) {
 
+    }
+
+    @Override
+    public long countByMemberAndStatus(Member member, PostStatus status) {
+        return jpaPostRepository.countByMemberAndStatus(member, PostStatus.PUBLISHED);
+    }
+
+    @Override
+    public long countByMemberAndStatusAndPublicityIn(Member member, PostStatus status, List<PublicityType> publicityTypes) {
+        return jpaPostRepository.countByMemberAndStatusAndPublicityIn(member, status, publicityTypes);
     }
 
     @Override
@@ -88,4 +99,6 @@ public class PostRepositoryAdaptor implements PostRepository {
     public List<CalendarPostDTO> findPostInfoByMemberAndMonth(int year, int month, Member member){
         return queryPostRepository.findPostInfoByMemberAndMonth(year, month, member);
     }
+
+
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
@@ -30,10 +30,10 @@ public interface MemberControllerDocs {
     @Operation(summary = "계정 탈퇴", description = "계정 탈퇴 기능입니다.")
     ApiResponse<String> resignMember(@CurrentMember Member member);
 
-    @Operation(summary = "[수정 중] 마이홈 본인 정보 조회", description = "마이홈 사용자 본인 정보 조회 기능입니다.")
+    @Operation(summary = "마이홈 본인 정보 조회", description = "마이홈 사용자 본인 정보 조회 기능입니다.")
     ApiResponse<MemberResponseDTO.MyHomeInfoDTO> getMyHomeInfo(@CurrentMember Member member);
 
-    @Operation(summary = "[수정 중] 마이홈 타사용자 정보 조회", description = "마이홈 타사용자 정보 조회 기능입니다.")
+    @Operation(summary = "마이홈 타사용자 정보 조회", description = "마이홈 타사용자 정보 조회 기능입니다.")
     @Parameter(name = "targetUsername", description = "타사용자의 username(로그인 아이디)")
     ApiResponse<MemberResponseDTO.UserHomeInfoDTO> getUserHomeInfo(@CurrentMember Member member, @PathVariable String targetUsername);
 

--- a/src/main/java/com/coredisc/presentation/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/member/MemberResponseDTO.java
@@ -25,7 +25,7 @@ public class MemberResponseDTO {
 
         private String followingCount;
 
-        private String discCount;
+        private String postCount;
 
         private ProfileImgResponseDTO.ProfileImgDTO profileImgDTO;
     }
@@ -46,7 +46,7 @@ public class MemberResponseDTO {
 
         private String followingCount;
 
-        private String discCount;
+        private String postCount;
 
         private Boolean isFollowing;
 


### PR DESCRIPTION
## 💡 작업 내용 요약
기존에 Disc 개수를 계산하여 응답에 포함하는 로직에서, 사용자의 게시글의 개수를 계산하는 로직으로 수정했습니다.

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #88 

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
