### PR TITLE
Feat: 이메일 전송, 인증코드 검증 관련 API 수정

### DIFF
--- a/src/main/java/com/coredisc/application/service/auth/AuthCommandService.java
+++ b/src/main/java/com/coredisc/application/service/auth/AuthCommandService.java
@@ -15,8 +15,11 @@ public interface AuthCommandService {
     // 이메일 코드 전송
     void sendCode(AuthRequestDTO.VerifyEmailDTO request, EmailRequestType requestType);
 
-    // 코드 인증
-    boolean verifyCode(AuthRequestDTO.VerifyCodeDTO request);
+    // 코드 인증 (회원가입)
+    boolean verifyCodeForSignUp(AuthRequestDTO.VerifyCodeForSignUpDTO request);
+
+    // 코드 인증 (비밀번호 변경)
+    boolean verifyCodeForResetPwd(AuthRequestDTO.VerifyCodeForResetPwdDTO request);
 
     // 로그인
     AuthResponseDTO.LoginResultDTO login(AuthRequestDTO.LoginDTO request);

--- a/src/main/java/com/coredisc/application/service/auth/AuthCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/auth/AuthCommandServiceImpl.java
@@ -136,19 +136,37 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         }
     }
 
-    // 코드 인증
+    // 코드 인증 (회원가입)
     @Override
-    public boolean verifyCode(AuthRequestDTO.VerifyCodeDTO request) {
+    public boolean verifyCodeForSignUp(AuthRequestDTO.VerifyCodeForSignUpDTO request) {
 
-        String authCode = (String) redisUtil.get("auth:" + request.getUsername() + ":" + request.getEmailRequestType());
+        verifyAuthCode(request.getEmail(), String.valueOf(request.getEmailRequestType()), request.getCode());
 
-        if (authCode == null) {
+        return true;
+    }
+
+    // 코드 인증 (비밀번호 변경)
+    @Override
+    public boolean verifyCodeForResetPwd(AuthRequestDTO.VerifyCodeForResetPwdDTO request) {
+
+        Member member = memberRepository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new AuthHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        verifyAuthCode(member.getEmail(), String.valueOf(request.getEmailRequestType()), request.getCode());
+        return true;
+    }
+
+    private void verifyAuthCode(String email, String requestType, String code) {
+
+        String key = "auth:" + email + ":" + requestType;
+        String storedCode = (String) redisUtil.get(key);
+
+        if (storedCode == null) {
             throw new AuthHandler(ErrorStatus.EMAIL_CODE_EXPIRED);
         }
-        if (!authCode.equals(request.getCode())) {
+        if (!storedCode.equals(code)) {
             throw new AuthHandler(ErrorStatus.CODE_NOT_EQUAL);
         }
-        return true;
     }
 
     // 로그인

--- a/src/main/java/com/coredisc/application/service/auth/MailService.java
+++ b/src/main/java/com/coredisc/application/service/auth/MailService.java
@@ -4,7 +4,6 @@ import com.coredisc.common.apiPayload.status.ErrorStatus;
 import com.coredisc.common.exception.handler.AuthHandler;
 import com.coredisc.common.util.RedisUtil;
 import com.coredisc.domain.common.enums.EmailRequestType;
-import com.coredisc.domain.member.Member;
 import com.coredisc.domain.member.MemberRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -52,7 +51,7 @@ public class MailService {
     }
 
     // 이메일 폼 생성
-    private MimeMessage createEmailForm(String username, String email, String code, EmailRequestType emailRequestType) throws MessagingException {
+    private MimeMessage createEmailForm(String email, String code, EmailRequestType emailRequestType) throws MessagingException {
 
         MimeMessage message = javaMailSender.createMimeMessage();
 
@@ -69,6 +68,8 @@ public class MailService {
                 message.setSubject("CoreDisc 비밀번호 변경 이메일 인증 코드 안내");
                 body += "<h3>비밀번호 변경을 위한 이메일 인증을 진행합니다.</h3>";
                 break;
+            default:
+                throw new AuthHandler(ErrorStatus.UNSUPPORTED_EMAIL_REQUEST_TYPE);
         }
 
         body += "<hr/>";
@@ -79,7 +80,7 @@ public class MailService {
         message.setText(body, "UTF-8", "html");
 
         // Redis에 해당 인증코드 인증 시간 설정(10분)
-        String redisKey = "auth:" + username + ":" + emailRequestType; // SIGNUP or RESET_PASSWORD 구분
+        String redisKey = "auth:" + email + ":" + emailRequestType; // SIGNUP or RESET_PASSWORD 구분
         redisUtil.set(redisKey, code);
         redisUtil.expire(redisKey, codeExpiration, TimeUnit.MILLISECONDS);
 
@@ -90,11 +91,12 @@ public class MailService {
     @Async
     public void sendEmail(String sendEmail, EmailRequestType emailRequestType) throws MessagingException {
 
-        Member member = memberRepository.findByEmail(sendEmail)
-                .orElseThrow(() -> new AuthHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        if(emailRequestType.equals(EmailRequestType.RESET_PASSWORD)) {
+            memberRepository.findByEmail(sendEmail)
+                    .orElseThrow(() -> new AuthHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        }
 
-        String username = member.getUsername();
-        String redisKey = "auth:" + username + ":" + emailRequestType;;
+        String redisKey = "auth:" + sendEmail + ":" + emailRequestType;
         if (redisUtil.exists(redisKey)) {
             redisUtil.delete(redisKey);
         }
@@ -102,7 +104,7 @@ public class MailService {
         String authCode = createCode();
         try {
             // 메일 생성
-            MimeMessage message = createEmailForm(username, sendEmail, authCode, emailRequestType);
+            MimeMessage message = createEmailForm(sendEmail, authCode, emailRequestType);
             // 메일 발송
             javaMailSender.send(message);
         } catch (MessagingException | MailSendException e) {

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -37,6 +37,7 @@ public enum ErrorStatus implements BaseErrorCode {
     UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH4017", "지원하지 않는 provider입니다."),
 
     // 인증코드 메일 전송 관련 에러
+    UNSUPPORTED_EMAIL_REQUEST_TYPE(HttpStatus.BAD_REQUEST, "EMAIL4001", "지원하지 않는 EmailRequestType 입니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL5001", "메일 전송에 실패했습니다."),
     EMAIL_WRITE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL5002", "메일 작성에 실패했습니다."),
 

--- a/src/main/java/com/coredisc/presentation/controller/AuthController.java
+++ b/src/main/java/com/coredisc/presentation/controller/AuthController.java
@@ -75,12 +75,21 @@ public class AuthController implements AuthControllerDocs {
         return ApiResponse.onSuccess("인증 메일이 성공적으로 전송되었습니다.");
     }
 
-    // 인증코드 검증
-    @PostMapping("/verify-code")
-    public ApiResponse<AuthResponseDTO.VerifyCodeResultDTO> verifyCode(@RequestBody @Valid AuthRequestDTO.VerifyCodeDTO request) {
+    // 회원가입 인증코드 검증
+    @PostMapping("/signup/verify-code")
+    public ApiResponse<AuthResponseDTO.VerifyCodeResultDTO> verifyCodeForSignUp(@RequestBody @Valid AuthRequestDTO.VerifyCodeForSignUpDTO request) {
 
         return ApiResponse.onSuccess(MemberConverter.toVerifyCodeResultDTO(
-                authCommandService.verifyCode(request)
+                authCommandService.verifyCodeForSignUp(request)
+        ));
+    }
+
+    // 비밀번호 변경 인증코드 검증
+    @PostMapping("/reset-password/verify-code")
+    public ApiResponse<AuthResponseDTO.VerifyCodeResultDTO> verifyCodeForResetPwd(AuthRequestDTO.VerifyCodeForResetPwdDTO request) {
+
+        return ApiResponse.onSuccess(MemberConverter.toVerifyCodeResultDTO(
+                authCommandService.verifyCodeForResetPwd(request)
         ));
     }
 

--- a/src/main/java/com/coredisc/presentation/controllerdocs/AuthControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/AuthControllerDocs.java
@@ -31,11 +31,14 @@ public interface AuthControllerDocs {
     @Parameter(name = "nickname", description = "닉네임")
     ApiResponse<AuthResponseDTO.CheckNicknameResultDTO> checkNickname(@RequestParam String nickname);
 
-    @Operation(summary = "[수정 중] 이메일 인증 메일 전송", description = "이메일 인증을 위한 메일 전송 기능입니다.")
+    @Operation(summary = "회원가입 이메일 인증 메일 전송", description = "회원가입 시 이메일 인증을 위한 메일 전송 기능입니다.")
     ApiResponse<String> sendCode(@RequestBody @Valid AuthRequestDTO.VerifyEmailDTO request);
 
-    @Operation(summary = "[수정 중] 이메일 코드 인증", description = "회원가입 시 이메일 코드 인증 기능입니다.")
-    ApiResponse<AuthResponseDTO.VerifyCodeResultDTO> verifyCode(@RequestBody @Valid AuthRequestDTO.VerifyCodeDTO request);
+    @Operation(summary = "회원가입 이메일 코드 인증", description = "회원가입 시 이메일 코드 인증 기능입니다.")
+    ApiResponse<AuthResponseDTO.VerifyCodeResultDTO> verifyCodeForSignUp(@RequestBody @Valid AuthRequestDTO.VerifyCodeForSignUpDTO request);
+
+    @Operation(summary = "비밀번호 변경 이메일 코드 인증", description = "비밀번호 변경 시 이메일 코드 인증 기능입니다.")
+    ApiResponse<AuthResponseDTO.VerifyCodeResultDTO> verifyCodeForResetPwd(@Valid @RequestBody AuthRequestDTO.VerifyCodeForResetPwdDTO request);
 
     @Operation(summary = "일반 로그인", description = "일반 로그인 기능입니다.")
     ApiResponse<AuthResponseDTO.LoginResultDTO> login(@RequestBody @Valid AuthRequestDTO.LoginDTO request);
@@ -49,7 +52,7 @@ public interface AuthControllerDocs {
     @Operation(summary = "아이디 찾기", description = "아이디 찾기 기능입니다. 이름과 이메일을 입력합니다.")
     ApiResponse<AuthResponseDTO.FindUsernameResultDTO> findUsername(@RequestBody @Valid AuthRequestDTO.FindUsernameDTO request);
 
-    @Operation(summary = "[수정 중] 비밀번호 변경을 위한 사용자 검증", description = "비밀변호 변경을 위해 사용자 검증을 진행합니다. 사용자가 존재하면 인증코드 메일을 보냅니다.")
+    @Operation(summary = "비밀번호 변경을 위한 사용자 검증", description = "비밀변호 변경을 위해 사용자 검증을 진행합니다. 사용자가 존재하면 인증코드 메일을 보냅니다.")
     ApiResponse<String> verifyUser(@RequestBody @Valid AuthRequestDTO.VerifyUserDTO request);
 
     @Operation(summary = "카카오 소셜 로그인", description = "카카오 인가 코드를 입력받아 로그인을 처리합니다.")

--- a/src/main/java/com/coredisc/presentation/dto/auth/AuthRequestDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/auth/AuthRequestDTO.java
@@ -52,16 +52,32 @@ public class AuthRequestDTO {
     }
 
     @Getter
-    public static class VerifyCodeDTO {
+    public static class VerifyCodeForSignUpDTO {
+
+        @NotBlank(message = "이메일 입력은 필수입니다.")
+        @Email(message = "이메일 형식이 맞지 않습니다.")
+        private String email;
+
+        @NotBlank(message = "인증 코드 입력은 필수입니다.")
+        private String code;
+
+        @NotNull
+        @Schema(description = "회원가입/비밀번호 변경 인증번호를 구분합니다.", example = "SIGNUP")
+        private EmailRequestType emailRequestType;
+    }
+
+    @Getter
+    public static class VerifyCodeForResetPwdDTO {
 
         @NotBlank(message = "아이디 입력은 필수입니다.")
+        @Schema(description = "username", example = "my_coredisc")
         private String username;
 
         @NotBlank(message = "인증 코드 입력은 필수입니다.")
         private String code;
 
         @NotNull
-        @Schema(description = "회원가입/비밀번호 변경 인증번호를 구분합니다. SIGNUP 또는 RESET_PASSWORD", example = "SIGNUP")
+        @Schema(description = "회원가입/비밀번호 변경 인증번호를 구분합니다.", example = "RESET_PASSWORD")
         private EmailRequestType emailRequestType;
     }
 


### PR DESCRIPTION
## 💡 작업 내용 요약
기존에 회원가입과 비밀번호 변경을 위한 코드 인증 로직을 하나의 API에서 처리했습니다.
하지만 요청 dto의 차이에서 오는 한계 때문에 두 개의 API로 분리하여 코드를 인증하도록 수정했습니다.

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #91

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
