### PR TITLE
Refactor: 카카오 로그인 API 수정

### DIFF
--- a/src/main/java/com/coredisc/application/service/auth/SocialAuthServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/auth/SocialAuthServiceImpl.java
@@ -17,20 +17,15 @@ import com.coredisc.presentation.dto.auth.AuthResponseDTO;
 import com.coredisc.presentation.dto.auth.KakaoUserInfo;
 import com.coredisc.security.auth.PrincipalDetails;
 import com.coredisc.security.jwt.JwtProvider;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -54,14 +49,8 @@ public class SocialAuthServiceImpl implements SocialAuthService {
         // yml 파일 social 아래 값 자바 객체로 매핑
         SocialProperties.ProviderProperties properties = getProviderProperties(provider);
 
-        // 인가 코드를 이용하여 AccessToken 가져옴
-        String accessToken = getAccessToken(
-                URLDecoder.decode(request.getCode(), StandardCharsets.UTF_8),
-                properties.getClientId(),
-                properties.getClientSecret(),
-                properties.getRedirectUri(),
-                properties.getTokenUri()
-        );
+        // 모바일 환경 : 클라이언트가 전달한 accessToken 직접 사용
+        String accessToken = request.getAccessToken();
 
         // AccessToken을 사용하여 유저 정보 가져옴
         Object userInfo = getUserInfo(
@@ -85,41 +74,6 @@ public class SocialAuthServiceImpl implements SocialAuthService {
             default:
                 throw new AuthHandler(ErrorStatus.UNSUPPORTED_PROVIDER);
         }
-    }
-
-    // 인가 코드를 이용하여 AccessToken 가져옴
-    private String getAccessToken(String code, String clientId, String clientSecret,
-                                  String redirectUri, String tokenUri) {
-
-        // HTTP Header 생성
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        // HTTP Body 생성
-        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add("grant_type", "authorization_code");
-        body.add("client_id", clientId);
-        body.add("client_secret", clientSecret);
-        body.add("redirect_uri", redirectUri);
-        body.add("code", code);
-
-        // HTTP 요청 보내기
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
-        try {
-            ResponseEntity<String> response = restTemplate.postForEntity(tokenUri, request, String.class);
-
-            if(response.getStatusCode() == HttpStatus.OK) {
-                ObjectMapper objectMapper = new ObjectMapper();
-                JsonNode jsonNode = objectMapper.readTree(response.getBody());
-
-                // Json 응답에서 access_token 추출
-                System.out.println(jsonNode);
-                return jsonNode.get("access_token").asText();
-            }
-        } catch (Exception e) {
-            throw new AuthHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
-        }
-        throw new AuthHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
     }
 
     // AccessToken을 사용하여 유저 정보 가져옴

--- a/src/main/java/com/coredisc/presentation/controllerdocs/AuthControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/AuthControllerDocs.java
@@ -55,6 +55,6 @@ public interface AuthControllerDocs {
     @Operation(summary = "비밀번호 변경을 위한 사용자 검증", description = "비밀변호 변경을 위해 사용자 검증을 진행합니다. 사용자가 존재하면 인증코드 메일을 보냅니다.")
     ApiResponse<String> verifyUser(@RequestBody @Valid AuthRequestDTO.VerifyUserDTO request);
 
-    @Operation(summary = "카카오 소셜 로그인", description = "카카오 인가 코드를 입력받아 로그인을 처리합니다.")
+    @Operation(summary = "카카오 소셜 로그인", description = "카카오 accessToken을 입력받아 로그인을 처리합니다.")
     ApiResponse<AuthResponseDTO.LoginResultDTO> kakaoLogin(@Valid @RequestBody AuthRequestDTO.SocialLoginDTO request);
 }

--- a/src/main/java/com/coredisc/presentation/dto/auth/AuthRequestDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/auth/AuthRequestDTO.java
@@ -117,7 +117,7 @@ public class AuthRequestDTO {
     @Getter
     public static class SocialLoginDTO {
 
-        @NotBlank(message = "인가 코드 입력은 필수입니다.")
-        String code;
+        @NotBlank(message = "access token 입력은 필수입니다.")
+        String accessToken;
     }
 }


### PR DESCRIPTION
## 💡 작업 내용 요약
카카오 소셜 로그인을 할 때 인가코드가 아닌 accessToken을 받아 로그인 하도록 로직 수정했습니다.

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #98

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
