### PR TITLE
Feat: 선택형 일기 배치 처리 구현(2)

### DIFF
--- a/src/main/java/com/coredisc/application/service/reportStat/ReportRawData.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportRawData.java
@@ -3,6 +3,7 @@ package com.coredisc.application.service.reportStat;
 import com.coredisc.domain.reportStats.DailyRandomQuestionStat;
 import com.coredisc.domain.reportStats.MonthlyFixedQuestionStat;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.List;
@@ -55,5 +56,16 @@ public class ReportRawData {
     public static class MostSelectedQuestionItem {
         private String questionContent;
         private int selectionCount;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    public static class SelectionStatKey {
+        private Long memberId;
+        private int year;
+        private int month;
+        private int dailyType;
+        private int selectedOption;
     }
 }

--- a/src/main/java/com/coredisc/application/service/reportStat/ReportStatBatchServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportStatBatchServiceImpl.java
@@ -1,6 +1,7 @@
 package com.coredisc.application.service.reportStat;
 
 import com.coredisc.common.converter.ReportStatConverter;
+import com.coredisc.common.util.DailyEnumMappingHelper;
 import com.coredisc.common.util.DateUtil;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.post.Post;
@@ -19,10 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -115,20 +113,56 @@ public class ReportStatBatchServiceImpl implements ReportStatBatchService {
         monthlyFixedQuestionStatRepository.saveAll(stats);
     }
 
-    // TODO: 구현 중...
     @Override
     @Transactional
     public void generateMonthlySelectionDiaryStats(LocalDate targetDate) {
-        // 그 날에 기록한 선택형 일기 데이터 저장
-
         List<Post> posts = postRepository.findPostsByCreatedDate(targetDate);
+        Map<ReportRawData.SelectionStatKey, Integer> aggregationMap = getAggregationMap(posts);
 
-        // TODO: 컨버터로 분리하기
-        List<MonthlySelectionDiaryStat> stats = posts.stream().map(post -> MonthlySelectionDiaryStat.builder()
-                .memberId(post.getMember().getId())
-                .year(post.getCreatedAt().getYear())
-                .month(post.getCreatedAt().getMonthValue())
-                .build()).toList();
-        monthlySelectionDiaryStatRepository.saveAll(stats);
+        List<MonthlySelectionDiaryStat> existingStats = monthlySelectionDiaryStatRepository
+                .findAllByYearAndMonth(targetDate.getYear(), targetDate.getMonthValue());
+
+        Map<ReportRawData.SelectionStatKey, MonthlySelectionDiaryStat> existingStatMap = existingStats.stream()
+                .collect(Collectors.toMap(
+                        stat -> new ReportRawData.SelectionStatKey(
+                                stat.getMemberId(),
+                                stat.getYear(),
+                                stat.getMonth(),
+                                stat.getDailyType(),
+                                stat.getSelectedOption()
+                        ),
+                        stat -> stat
+                ));
+
+        List<MonthlySelectionDiaryStat> statsToSave = aggregationMap.entrySet().stream()
+                .map(entry -> ReportStatConverter.toOrUpdateMonthlySelectionDiaryStat(entry, existingStatMap))
+                .toList();
+
+        monthlySelectionDiaryStatRepository.saveAll(statsToSave);
+    }
+
+
+    private static Map<ReportRawData.SelectionStatKey, Integer> getAggregationMap(List<Post> posts) {
+        Map<ReportRawData.SelectionStatKey, Integer> aggregationMap = new HashMap<>();
+
+        for (Post post : posts) {
+            Long memberId = post.getMember().getId();
+            int year = post.getCreatedAt().getYear();
+            int month = post.getCreatedAt().getMonthValue();
+
+            int whoOption = DailyEnumMappingHelper.toSelectedOption(post.getDailyWho());
+            ReportRawData.SelectionStatKey keyWho = new ReportRawData.SelectionStatKey(memberId, year, month, 1, whoOption);
+            aggregationMap.put(keyWho, aggregationMap.getOrDefault(keyWho, 0) + 1);
+
+            int whereOption = DailyEnumMappingHelper.toSelectedOption(post.getDailyWhere());
+            ReportRawData.SelectionStatKey keyWhere = new ReportRawData.SelectionStatKey(memberId, year, month, 2, whereOption);
+            aggregationMap.put(keyWhere, aggregationMap.getOrDefault(keyWhere, 0) + 1);
+
+            int whatOption = DailyEnumMappingHelper.toSelectedOption(post.getDailyWhat());
+            ReportRawData.SelectionStatKey keyWhat = new ReportRawData.SelectionStatKey(memberId, year, month, 3, whatOption);
+            aggregationMap.put(keyWhat, aggregationMap.getOrDefault(keyWhat, 0) + 1);
+        }
+
+        return aggregationMap;
     }
 }

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -65,6 +65,9 @@ public enum ErrorStatus implements BaseErrorCode {
     //통계 관련 에러
     STATS_NOT_FOUND(HttpStatus.NOT_FOUND, "STATS4001","요청한 통계 데이터를 찾을 수 없습니다."),
     STATS_NOT_MEANINGFUL(HttpStatus.NO_CONTENT, "STATS4002","통계 데이터가 유의미하지 않거나 충분하지 않습니다."),
+    INVALID_SELECTED_OPTION(HttpStatus.BAD_REQUEST, "STATS4003", "선택형 일기 옵션 번호가 잘못되었습니다."),
+    INVALID_DAILY_TYPE(HttpStatus.BAD_REQUEST, "STATS4004", "존재하지 않는 dailyType입니다."),
+    INVALID_LABEL_MAPPING(HttpStatus.BAD_REQUEST, "STATS4005", "라벨 매핑에 실패했습니다."),
 
 
     // 답변 관련 예외

--- a/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
+++ b/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
@@ -13,10 +13,8 @@ import com.coredisc.domain.todayQuestion.TodayQuestion;
 import com.coredisc.presentation.dto.reportStat.ReportStatResponseDTO;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class ReportStatConverter {
 
@@ -143,14 +141,20 @@ public class ReportStatConverter {
     public static List<MonthlyFixedQuestionStat> toMonthlyFixedQuestionStats(List<TodayQuestion> questions, Set<Long> memberIds, int year, int month) {
         return questions.stream()
                 .filter(q -> memberIds.contains(q.getMember().getId()))
-                .map(q -> MonthlyFixedQuestionStat.builder()
-                        .memberId(q.getMember().getId())
-                        .year(year)
-                        .month(month)
-                        .questionOrder(q.getQuestionOrder())
-                        .questionContent(q.getQuestionContent())
-                        .build())
-                .toList();
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toMap(
+                                q -> q.getMember().getId() + "-" + q.getQuestionOrder(),
+                                q -> MonthlyFixedQuestionStat.builder()
+                                        .memberId(q.getMember().getId())
+                                        .year(year)
+                                        .month(month)
+                                        .questionOrder(q.getQuestionOrder())
+                                        .questionContent(q.getQuestionContent())
+                                        .build(),
+                                (existing, replacement) -> existing
+                        ),
+                        map -> new ArrayList<>(map.values())
+                ));
     }
 
     public static MonthlySelectionDiaryStat toOrUpdateMonthlySelectionDiaryStat(

--- a/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
+++ b/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
@@ -1,12 +1,14 @@
 package com.coredisc.common.converter;
 
 import com.coredisc.application.service.reportStat.ReportRawData;
+import com.coredisc.common.util.DailyEnumMappingHelper;
 import com.coredisc.domain.common.enums.TimeZoneType;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.post.Post;
 import com.coredisc.domain.reportStats.DailyAnswerHourStat;
 import com.coredisc.domain.reportStats.DailyRandomQuestionStat;
 import com.coredisc.domain.reportStats.MonthlyFixedQuestionStat;
+import com.coredisc.domain.reportStats.MonthlySelectionDiaryStat;
 import com.coredisc.domain.todayQuestion.TodayQuestion;
 import com.coredisc.presentation.dto.reportStat.ReportStatResponseDTO;
 
@@ -94,10 +96,11 @@ public class ReportStatConverter {
                     int selectedOption = entry.getValue().getSelectedOption();
                     int selectionCount = entry.getValue().getSelectionCount();
 
-                    String optionContent = String.valueOf(selectedOption);
+                    String dailyTypeContent = DailyEnumMappingHelper.toDailyTypeName(dailyType);
+                    String optionContent = DailyEnumMappingHelper.toLabelFromSelectedOption(dailyType, selectedOption);
 
                     return ReportStatResponseDTO.DailyOptionDTO.builder()
-                            .dailyType(dailyType)
+                            .dailyType(dailyTypeContent)
                             .optionContent(optionContent)
                             .selectionCount(selectionCount)
                             .build();
@@ -148,5 +151,30 @@ public class ReportStatConverter {
                         .questionContent(q.getQuestionContent())
                         .build())
                 .toList();
+    }
+
+    public static MonthlySelectionDiaryStat toOrUpdateMonthlySelectionDiaryStat(
+            Map.Entry<ReportRawData.SelectionStatKey, Integer> entry,
+            Map<ReportRawData.SelectionStatKey, MonthlySelectionDiaryStat> existingStatMap) {
+
+        ReportRawData.SelectionStatKey key = entry.getKey();
+        int countToAdd = entry.getValue();
+
+        MonthlySelectionDiaryStat existingStat = existingStatMap.get(key);
+
+        if (existingStat != null) {
+            existingStat.setSelectionCount(existingStat.getSelectionCount() + countToAdd);
+            return existingStat;
+        } else {
+            // 없으면 새로 생성
+            return MonthlySelectionDiaryStat.builder()
+                    .memberId(key.getMemberId())
+                    .year(key.getYear())
+                    .month(key.getMonth())
+                    .dailyType(key.getDailyType())
+                    .selectedOption(key.getSelectedOption())
+                    .selectionCount(countToAdd)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/coredisc/common/util/DailyEnumMappingHelper.java
+++ b/src/main/java/com/coredisc/common/util/DailyEnumMappingHelper.java
@@ -1,0 +1,112 @@
+package com.coredisc.common.util;
+
+import com.coredisc.common.apiPayload.status.ErrorStatus;
+import com.coredisc.common.exception.handler.ReportStatHandler;
+import com.coredisc.domain.common.enums.DiaryWhat;
+import com.coredisc.domain.common.enums.DiaryWhere;
+import com.coredisc.domain.common.enums.DiaryWho;
+
+import java.util.Map;
+
+public class DailyEnumMappingHelper {
+
+    // label 매핑
+    private static final Map<DiaryWho, String> diaryWhoLabelMap = Map.of(
+            DiaryWho.ALONE, "혼자",
+            DiaryWho.FRIEND, "친구",
+            DiaryWho.FAMILY, "가족",
+            DiaryWho.COLLEAGUE, "동료",
+            DiaryWho.LOVER, "연인",
+            DiaryWho.PET, "반려동물"
+    );
+
+    private static final Map<DiaryWhere, String> diaryWhereLabelMap = Map.of(
+            DiaryWhere.HOME, "집",
+            DiaryWhere.COMPANY, "회사",
+            DiaryWhere.SCHOOL, "학교",
+            DiaryWhere.CAFE, "카페",
+            DiaryWhere.OUTDOOR, "야외",
+            DiaryWhere.ON_THE_MOVE, "이동 중"
+    );
+
+    private static final Map<DiaryWhat, String> diaryWhatLabelMap = Map.of(
+            DiaryWhat.WORK, "일",
+            DiaryWhat.STUDY, "공부",
+            DiaryWhat.EXERCISE, "운동",
+            DiaryWhat.REST, "휴식",
+            DiaryWhat.SLEEP, "수면",
+            DiaryWhat.HOBBY, "취미"
+    );
+
+    // enum → selectedOption (1~6)
+    public static int toSelectedOption(Enum<?> enumValue) {
+        return enumValue.ordinal() + 1;
+    }
+
+    // selectedOption → enum
+    public static Enum<?> fromSelectedOption(int dailyType, int selectedOption) {
+        if (selectedOption < 1 || selectedOption > 6) {
+            throw new ReportStatHandler(ErrorStatus.INVALID_SELECTED_OPTION);
+        }
+
+        return switch (dailyType) {
+            case 1 -> DiaryWho.values()[selectedOption - 1];
+            case 2 -> DiaryWhere.values()[selectedOption - 1];
+            case 3 -> DiaryWhat.values()[selectedOption - 1];
+            default -> throw new ReportStatHandler(ErrorStatus.INVALID_DAILY_TYPE);
+        };
+    }
+
+    // enum → label
+    public static String toLabel(Enum<?> enumValue) {
+        if (enumValue instanceof DiaryWho who) {
+            return diaryWhoLabelMap.get(who);
+        } else if (enumValue instanceof DiaryWhere where) {
+            return diaryWhereLabelMap.get(where);
+        } else if (enumValue instanceof DiaryWhat what) {
+            return diaryWhatLabelMap.get(what);
+        } else {
+            throw new ReportStatHandler(ErrorStatus.INVALID_LABEL_MAPPING);
+        }
+    }
+
+    // label → enum
+    public static Enum<?> fromLabel(int dailyType, String label) {
+        return switch (dailyType) {
+            case 1 -> findEnumByLabel(diaryWhoLabelMap, label);
+            case 2 -> findEnumByLabel(diaryWhereLabelMap, label);
+            case 3 -> findEnumByLabel(diaryWhatLabelMap, label);
+            default -> throw new ReportStatHandler(ErrorStatus.INVALID_DAILY_TYPE);
+        };
+    }
+
+    // selectedOption → label
+    public static String toLabelFromSelectedOption(int dailyType, int selectedOption) {
+        Enum<?> enumValue = fromSelectedOption(dailyType, selectedOption);
+        return toLabel(enumValue);
+    }
+
+    // label → selectedOption
+    public static int toSelectedOptionFromLabel(int dailyType, String label) {
+        Enum<?> enumValue = fromLabel(dailyType, label);
+        return toSelectedOption(enumValue);
+    }
+
+    // 질문 이름 가져오기
+    public static String toDailyTypeName(int dailyType) {
+        return switch (dailyType) {
+            case 1 -> "누구와 가장 많이 있었을까요?";
+            case 2 -> "어디에 가장 많이 있었을까요?";
+            case 3 -> "무엇을 가장 많이 했을까요?";
+            default -> throw new ReportStatHandler(ErrorStatus.INVALID_DAILY_TYPE);
+        };
+    }
+
+    private static <E extends Enum<E>> E findEnumByLabel(Map<E, String> map, String label) {
+        return map.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(label))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElseThrow(() -> new ReportStatHandler(ErrorStatus.INVALID_LABEL_MAPPING));
+    }
+}

--- a/src/main/java/com/coredisc/domain/reportStats/DailyRandomQuestionStat.java
+++ b/src/main/java/com/coredisc/domain/reportStats/DailyRandomQuestionStat.java
@@ -25,6 +25,6 @@ public class DailyRandomQuestionStat extends BaseEntity {
     @Column(nullable = false)
     private LocalDate selectedDate;
 
-    @Column(nullable = false, length = 100) //질문 길이 얼마지??
+    @Column(nullable = false, length = 50)
     private String questionContent;
 }

--- a/src/main/java/com/coredisc/domain/reportStats/MonthlyFixedQuestionStat.java
+++ b/src/main/java/com/coredisc/domain/reportStats/MonthlyFixedQuestionStat.java
@@ -33,6 +33,6 @@ public class MonthlyFixedQuestionStat extends BaseEntity {
     @Min(1) @Max(3)
     private int questionOrder;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 50)
     private String questionContent;
 }

--- a/src/main/java/com/coredisc/domain/reportStats/MonthlySelectionDiaryStat.java
+++ b/src/main/java/com/coredisc/domain/reportStats/MonthlySelectionDiaryStat.java
@@ -33,9 +33,10 @@ public class MonthlySelectionDiaryStat extends BaseEntity {
     private int dailyType; // 1, 2, 3 (데일리 질문 3개)
 
     @Column(nullable = false)
-    private int selectedOption; // 1~5 (선택된 옵션)
+    private int selectedOption; // 1~6 (선택된 옵션)
 
     @Column(nullable = false)
     @Min(0)
+    @Setter
     private int selectionCount; // 해당 옵션이 선택된 횟수
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/reportStat/MonthlySelectionDiaryStatRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/reportStat/MonthlySelectionDiaryStatRepository.java
@@ -24,4 +24,6 @@ public interface MonthlySelectionDiaryStatRepository extends JpaRepository<Month
             @Param("year") int year,
             @Param("month") int month,
             @Param("dailyType") int dailyType);
+
+    List<MonthlySelectionDiaryStat> findAllByYearAndMonth(int year, int month);
 }

--- a/src/main/java/com/coredisc/infrastructure/schedule/BatchScheduler.java
+++ b/src/main/java/com/coredisc/infrastructure/schedule/BatchScheduler.java
@@ -73,7 +73,12 @@ public class BatchScheduler {
             log.error("[배치] generateRandomQuestionsStats 에러: {}", e.getMessage(), e);
         }
 
-        // TODO: 추후 추가 배치 작업 에러 처리도 여기에 포함
+        try {
+            reportStatBatchService.generateMonthlySelectionDiaryStats(targetDate);
+        } catch (Exception e) {
+            errorCount++;
+            log.error("[배치] generateMonthlySelectionDiaryStats 에러: {}", e.getMessage(), e);
+        }
 
         if (errorCount > 0) {
             log.warn("[배치] {}일자 통계 배치 작업 완료 - 에러 발생 횟수: {}", targetDate, errorCount);

--- a/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatResponseDTO.java
@@ -100,7 +100,7 @@ public class ReportStatResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DailyOptionDTO{ //선택형 일기 옵션
-        private int dailyType;
+        private String dailyType;
         private String optionContent;
         private int selectionCount;
     }


### PR DESCRIPTION
## 💡 작업 내용 요약
- 월별 리포트에서 사용할 선택형 일기 답변 데이터를 저장하는 배치 처리 로직을 작성했습니다. 
- 매일 자정 전날 작성된 Post 데이터를 기반으로 각 항목(DiaryWho, DiaryWhere, DiaryWhat)의 선택 옵션 개수를 집계하여 저장합니다.

- 추가로, 컨트롤러에서 통계 데이터를 조회할 때 문자열 형태로 출력되도록 수정했습니다. 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #97 

## 📎 기타 참고사항
집계 테이블에서는 질문과 선택 옵션 둘 다 숫자로 저장하고, dto로 내보낼 때에만 문자열로 변환합니다. 