### PR TITLE
Feat: 한 달치 데일리 일기 조회 API 구현

### DIFF
--- a/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryService.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryService.java
@@ -1,6 +1,9 @@
 package com.coredisc.application.service.reportStat;
 
-import java.time.LocalDate;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.post.Post;
+
+import java.util.List;
 
 public interface ReportStatQueryService {
 
@@ -15,4 +18,7 @@ public interface ReportStatQueryService {
 
     // 기간별 게시글의 daily_ 항목 최다 답변 조회
     ReportRawData.DailyOptionRawData getMostSelectedDaily(int year, int month, Long memberId);
+
+    // 기간별 daily_detail 항목 답변 목록 조회
+    List<Post> getDailyDetails(int year, int month, Member member);
 }

--- a/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryServiceImpl.java
@@ -3,6 +3,9 @@ package com.coredisc.application.service.reportStat;
 import com.coredisc.common.apiPayload.status.ErrorStatus;
 import com.coredisc.common.exception.handler.ReportStatHandler;
 import com.coredisc.common.util.DateUtil;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.post.Post;
+import com.coredisc.domain.post.PostRepository;
 import com.coredisc.domain.reportStats.DailyRandomQuestionStat;
 import com.coredisc.domain.reportStats.MonthlyFixedQuestionStat;
 import com.coredisc.infrastructure.repository.reportStat.DailyAnswerHourStatRepository;
@@ -15,6 +18,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
 import java.util.*;
 
 
@@ -26,6 +32,7 @@ public class ReportStatQueryServiceImpl implements ReportStatQueryService{
     private final DailyRandomQuestionStatRepository randomQuestionRepository;
     private final MonthlyFixedQuestionStatRepository fixedQuestionRepository;
     private final MonthlySelectionDiaryStatRepository monthlySelectionDiaryStatRepository;
+    private final PostRepository postRepository;
 
     @Override
     public ReportRawData.QuestionListRawData getQuestionList(int year, int month, Long memberId) {
@@ -110,4 +117,13 @@ public class ReportStatQueryServiceImpl implements ReportStatQueryService{
 
         return new ReportRawData.DailyOptionRawData(year, month, topOptionMap);
     }
+
+    @Override
+    public List<Post> getDailyDetails(int year, int month, Member member) {
+        LocalDateTime start = DateUtil.getStartDateTime(year, month);
+        LocalDateTime end = DateUtil.getEndDateTime(year, month);
+
+        return postRepository.findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(member, start, end);
+    }
+
 }

--- a/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
+++ b/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
@@ -11,10 +11,8 @@ import com.coredisc.domain.todayQuestion.TodayQuestion;
 import com.coredisc.presentation.dto.reportStat.ReportStatResponseDTO;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class ReportStatConverter {
 
@@ -24,7 +22,6 @@ public class ReportStatConverter {
     }
 
     public static ReportStatResponseDTO.PeakHourDTO toPeakHourDTO(ReportRawData.HourlyAnswerRawData rawData) {
-        // 최다 응답 시간대 찾기 -> 이 부분 고민 중...
         Map.Entry<Integer, Integer> maxEntry = rawData.getHourCountMap().entrySet().stream()
                 .max(Map.Entry.comparingByValue())
                 .orElse(null);
@@ -148,5 +145,19 @@ public class ReportStatConverter {
                         .questionContent(q.getQuestionContent())
                         .build())
                 .toList();
+    }
+
+    public static ReportStatResponseDTO.DailyDetailListDTO toDailyDetailListDTO(List<Post> posts) {
+        Map<LocalDate, String> detailMap = posts.stream()
+                .collect(Collectors.toMap(
+                        post -> post.getCreatedAt().toLocalDate(),
+                        Post::getDailyDetail,
+                        (oldValue, newValue) -> newValue,
+                        LinkedHashMap::new
+                ));
+
+        return ReportStatResponseDTO.DailyDetailListDTO.builder()
+                .dailyDetails(detailMap)
+                .build();
     }
 }

--- a/src/main/java/com/coredisc/domain/post/PostRepository.java
+++ b/src/main/java/com/coredisc/domain/post/PostRepository.java
@@ -44,6 +44,7 @@ public interface PostRepository {
     List<Post> findPostsByCreatedDate(LocalDate targetDate);
     List<Long> findDistinctMemberIdsByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
     List<Member> findMembersByPostCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+    List<Post> findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(Member member, LocalDateTime start, LocalDateTime end);
 
     // 특정 회원이 특정 날짜에 발행한 게시글이 있는가?
     boolean existsByMemberAndStatusAndCreatedAtBetween(Member member, PostStatus status, LocalDateTime startOfDay, LocalDateTime endOfDay);

--- a/src/main/java/com/coredisc/infrastructure/repository/post/JpaPostRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/post/JpaPostRepository.java
@@ -17,6 +17,8 @@ public interface JpaPostRepository extends JpaRepository<Post, Long> {
 
     long countByMemberAndStatus(Member member, PostStatus status);
     long countByMemberAndStatusAndPublicityIn(Member member, PostStatus status, List<PublicityType> publicityTypes);
+
+    List<Post> findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(Member member, LocalDateTime start, LocalDateTime end);
 }
 
 

--- a/src/main/java/com/coredisc/infrastructure/repository/post/PostRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/post/PostRepositoryAdaptor.java
@@ -123,4 +123,9 @@ public class PostRepositoryAdaptor implements PostRepository {
     public List<Member> findMembersByPostCreatedAtBetween(LocalDateTime start, LocalDateTime end) {
         return queryPostRepository.findMembersByPostCreatedAtBetween(start, end);
     }
+
+    @Override
+    public List<Post> findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(Member member, LocalDateTime start, LocalDateTime end) {
+        return jpaPostRepository.findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(member, start, end);
+    }
 }

--- a/src/main/java/com/coredisc/presentation/controller/CalendarController.java
+++ b/src/main/java/com/coredisc/presentation/controller/CalendarController.java
@@ -9,6 +9,7 @@ import com.coredisc.security.jwt.annotaion.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,7 +21,7 @@ public class CalendarController implements CalendarControllerDocs {
 
     // 캘린더 조회
     @GetMapping
-    public ApiResponse<CalendarResponseDTO.CalendarDTO> getCalendar(int year, int month, @CurrentMember Member member) {
+    public ApiResponse<CalendarResponseDTO.CalendarDTO> getCalendar(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
         return ApiResponse.onSuccess(calendarQueryService.getCalendar(year, month, member));
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/ReportStatController.java
+++ b/src/main/java/com/coredisc/presentation/controller/ReportStatController.java
@@ -10,6 +10,7 @@ import com.coredisc.security.jwt.annotaion.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,32 +22,31 @@ public class ReportStatController implements ReportStatControllerDocs {
 
     // 사용자가 특정 달에 선택한 고정 질문 3개와 랜덤 질문 목록 조회
     @GetMapping("/question-list")
-    public ApiResponse<ReportStatResponseDTO.QuestionListDTO> getMonthlyQuestionList(int year, int month, @CurrentMember Member member) {
+    public ApiResponse<ReportStatResponseDTO.QuestionListDTO> getMonthlyQuestionList(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
         return ApiResponse.onSuccess(ReportStatConverter.toQuestionListDTO(reportStatQueryService.getQuestionList(year, month, member.getId())));
     }
 
     // 사용자가 특정 달 동안 가장 많이 선택한 랜덤 질문 3개 조회
     @GetMapping("/most-selected")
-    public ApiResponse<ReportStatResponseDTO.MostSelectedQuestionDTO> getMostSelectedQuestions(int year, int month, @CurrentMember Member member) {
+    public ApiResponse<ReportStatResponseDTO.MostSelectedQuestionDTO> getMostSelectedQuestions(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
         return ApiResponse.onSuccess(ReportStatConverter.toMostSelectedQuestionDTO(reportStatQueryService.getMostSelectedQuestions(year, month, member.getId())));
     }
 
     // 사용자가 특정 달에 시간대 별로 응답한 횟수 조회
     @GetMapping("/peak-hours")
-    public ApiResponse<ReportStatResponseDTO.PeakHourDTO> getPeakHour(int year, int month, @CurrentMember Member member) {
+    public ApiResponse<ReportStatResponseDTO.PeakHourDTO> getPeakHour(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
         return ApiResponse.onSuccess(ReportStatConverter.toPeakHourDTO(reportStatQueryService.getHourlyAnswerCountMap(year, month, member.getId())));
     }
 
     // 사용자가 선택형 일기에서 특정 달에 가장 많이 선택한 옵션 조회
     @GetMapping("/daily/top-selection")
-    public ApiResponse<ReportStatResponseDTO.TopDailySelectionDTO> getMostSelectedDaily(int year, int month, @CurrentMember Member member) {
+    public ApiResponse<ReportStatResponseDTO.TopDailySelectionDTO> getMostSelectedDaily(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
         return ApiResponse.onSuccess(ReportStatConverter.toTopDailySelectionDTO(reportStatQueryService.getMostSelectedDaily(year, month, member.getId())));
     }
 
     // 사용자가 특정 달에 작성한 일기 내용 전체 출력
-    // TODO : 추후 작성할 예정
     @GetMapping("/daily/details")
-    public ApiResponse<ReportStatResponseDTO.DailyDetailListDTO> getDailyDetail(int year, int month, @CurrentMember Member member) {
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<ReportStatResponseDTO.DailyDetailListDTO> getDailyDetail(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
+        return ApiResponse.onSuccess(ReportStatConverter.toDailyDetailListDTO(reportStatQueryService.getDailyDetails(year, month, member)));
     }
 }

--- a/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatResponseDTO.java
@@ -4,8 +4,8 @@ import com.coredisc.domain.common.enums.TimeZoneType;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ReportStatResponseDTO {
 
@@ -57,7 +57,7 @@ public class ReportStatResponseDTO {
     @AllArgsConstructor
     @Setter
     public static class DailyDetailListDTO{
-        private HashMap<LocalDate, String> dailyDetails;
+        private Map<LocalDate, String> dailyDetails;
     }
 
     @Builder


### PR DESCRIPTION
## 💡 작업 내용 요약
daily_details 주관식 답변 문항 모아보는 API 구현했습니다. 
별도 집계 로직 없이 내용만 나열하면 되는 API라서 통계용 테이블에 저장하는 과정 없이 바로 Post에서 받아올 수 있도록 했습니다. 
아무리 많아도 최대 31개까지라서 문제 없을 것으로 보입니다~! 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #111

## 📎 기타 참고사항
제가.... 컨트롤러에 @RequestParam을 안 붙였더라고요.......? 같이 추가했습니다.... 
