### PR TITLE
Refactor: 월별 리포트 조회 API 수정

### DIFF
--- a/src/main/java/com/coredisc/application/service/reportStat/ReportRawData.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportRawData.java
@@ -13,17 +13,23 @@ public class ReportRawData {
 
     @Getter
     @AllArgsConstructor
-    public static class HourlyAnswerRawData {
+    public static class MonthlyReportRawData{
         private int year;
         private int month;
+        private QuestionListRawData questionListRaw;
+        private MostSelectedQuestionRawData mostSelectedRaw;
+        private HourlyAnswerRawData peakHourRaw;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class HourlyAnswerRawData {
         private Map<Integer, Integer> hourCountMap;
     }
 
     @Getter
     @AllArgsConstructor
     public static class MostSelectedQuestionRawData {
-        private int year;
-        private int month;
         private boolean isAllOneCount;
         private List<MostSelectedQuestionItem> questions;
     }
@@ -31,8 +37,6 @@ public class ReportRawData {
     @Getter
     @AllArgsConstructor
     public static class QuestionListRawData {
-        private int year;
-        private int month;
         private List<MonthlyFixedQuestionStat> fixedQuestions;
         private List<DailyRandomQuestionStat> randomQuestions;
     }

--- a/src/main/java/com/coredisc/application/service/reportStat/ReportRawData.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportRawData.java
@@ -24,6 +24,7 @@ public class ReportRawData {
     public static class MostSelectedQuestionRawData {
         private int year;
         private int month;
+        private boolean isAllOneCount;
         private List<MostSelectedQuestionItem> questions;
     }
 

--- a/src/main/java/com/coredisc/application/service/reportStat/ReportStatBatchServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportStatBatchServiceImpl.java
@@ -38,7 +38,6 @@ public class ReportStatBatchServiceImpl implements ReportStatBatchService {
     @Override
     @Transactional
     public void generateDailyStatistics(LocalDate targetDate) {
-        // 그날에 답변한 시간 데이터 저장
 
         List<Post> posts = postRepository.findPostsByCreatedDate(targetDate);
         List<DailyAnswerHourStat> stats = ReportStatConverter.toDailyAnswerHourStats(posts, targetDate);
@@ -106,10 +105,8 @@ public class ReportStatBatchServiceImpl implements ReportStatBatchService {
                         targetMonth.atDay(1),
                         targetMonth.atEndOfMonth());
 
-        // 컨버터로 변환
         List<MonthlyFixedQuestionStat> stats = ReportStatConverter.toMonthlyFixedQuestionStats(questions, newMemberIds, year, month);
 
-        // 저장
         monthlyFixedQuestionStatRepository.saveAll(stats);
     }
 

--- a/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryService.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryService.java
@@ -7,14 +7,8 @@ import java.util.List;
 
 public interface ReportStatQueryService {
 
-    // 기간별 전체 질문 목록 조회 (고정 질문 + 랜덤 질문)
-    ReportRawData.QuestionListRawData getQuestionList(int year, int month, Long memberId);
-
-    // 기간별 최다 선택된 랜덤 질문 조회
-    ReportRawData.MostSelectedQuestionRawData getMostSelectedQuestions(int year, int month, Long memberId);
-
-    // 기간별 응답 시간대 횟수 조회
-    ReportRawData.HourlyAnswerRawData getHourlyAnswerCountMap(int year, int month, Long memberId);
+    // 웗별 리포트 rawData 조회
+    ReportRawData.MonthlyReportRawData getMonthlyReportRawData(int year, int month, Long memberId);
 
     // 기간별 게시글의 daily_ 항목 최다 답변 조회
     ReportRawData.DailyOptionRawData getMostSelectedDaily(int year, int month, Long memberId);

--- a/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryServiceImpl.java
@@ -19,8 +19,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.YearMonth;
 import java.util.*;
 
 
@@ -45,8 +43,7 @@ public class ReportStatQueryServiceImpl implements ReportStatQueryService{
         LocalDate start = DateUtil.getStartDate(year, month);
         LocalDate end = DateUtil.getEndDate(year, month);
 
-        List<DailyRandomQuestionStat> randomQuestions = randomQuestionRepository.findByMemberIdAndSelectedDateRange(
-                memberId, start, end);
+        List<DailyRandomQuestionStat> randomQuestions = randomQuestionRepository.findByMemberIdAndSelectedDateRange(memberId, start, end);
 
         return new ReportRawData.QuestionListRawData(year, month, fixedQuestions, randomQuestions);
     }
@@ -59,18 +56,18 @@ public class ReportStatQueryServiceImpl implements ReportStatQueryService{
         LocalDate endDate = DateUtil.getEndDate(year, month);
 
         List<Object[]> results = randomQuestionRepository.findTop3QuestionsByMemberAndDateRange(memberId, startDate, endDate, top3);
-        if(results.isEmpty()) {
-            throw new ReportStatHandler(ErrorStatus.STATS_NOT_FOUND);
-        }
+
+        boolean allCountIsOne = results.stream()
+                .allMatch(obj -> ((Long) obj[1]) == 1L);
 
         List<ReportRawData.MostSelectedQuestionItem> topQuestions = new ArrayList<>();
         for (Object[] row : results) {
             String questionContent = (String) row[0];
             int selectionCount = ((Number) row[1]).intValue();
-
             topQuestions.add(new ReportRawData.MostSelectedQuestionItem(questionContent, selectionCount));
         }
-        return new ReportRawData.MostSelectedQuestionRawData(startDate.getYear(), startDate.getMonthValue(), topQuestions);
+
+        return new ReportRawData.MostSelectedQuestionRawData(year, month, allCountIsOne, topQuestions);
     }
 
     @Override
@@ -94,9 +91,8 @@ public class ReportStatQueryServiceImpl implements ReportStatQueryService{
             hourCountMap.putIfAbsent(i, 0);
         }
 
-        return new ReportRawData.HourlyAnswerRawData(startDate.getYear(), startDate.getMonthValue(), hourCountMap);
+        return new ReportRawData.HourlyAnswerRawData(year, month, hourCountMap);
     }
-
 
     @Override
     public ReportRawData.DailyOptionRawData getMostSelectedDaily(int year, int month, Long memberId) {
@@ -125,5 +121,4 @@ public class ReportStatQueryServiceImpl implements ReportStatQueryService{
 
         return postRepository.findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(member, start, end);
     }
-
 }

--- a/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryServiceImpl.java
@@ -33,65 +33,12 @@ public class ReportStatQueryServiceImpl implements ReportStatQueryService{
     private final PostRepository postRepository;
 
     @Override
-    public ReportRawData.QuestionListRawData getQuestionList(int year, int month, Long memberId) {
-        List<MonthlyFixedQuestionStat> fixedQuestions = fixedQuestionRepository.findByMemberIdAndYearAndMonthOrderByQuestionOrder(
-                memberId, year, month);
-        if(fixedQuestions.isEmpty()) {
-            throw new ReportStatHandler(ErrorStatus.STATS_NOT_FOUND);
-        }
+    public ReportRawData.MonthlyReportRawData getMonthlyReportRawData(int year, int month, Long memberId) {
+        ReportRawData.QuestionListRawData questionListRaw = getQuestionList(year, month, memberId);
+        ReportRawData.MostSelectedQuestionRawData mostSelectedRaw = getMostSelectedQuestions(year, month, memberId);
+        ReportRawData.HourlyAnswerRawData peakHourRaw = getHourlyAnswerCountMap(year, month, memberId);
 
-        LocalDate start = DateUtil.getStartDate(year, month);
-        LocalDate end = DateUtil.getEndDate(year, month);
-
-        List<DailyRandomQuestionStat> randomQuestions = randomQuestionRepository.findByMemberIdAndSelectedDateRange(memberId, start, end);
-
-        return new ReportRawData.QuestionListRawData(year, month, fixedQuestions, randomQuestions);
-    }
-
-    @Override
-    public ReportRawData.MostSelectedQuestionRawData getMostSelectedQuestions(int year, int month, Long memberId) {
-        Pageable top3 = PageRequest.of(0, 3);
-
-        LocalDate startDate = DateUtil.getStartDate(year, month);
-        LocalDate endDate = DateUtil.getEndDate(year, month);
-
-        List<Object[]> results = randomQuestionRepository.findTop3QuestionsByMemberAndDateRange(memberId, startDate, endDate, top3);
-
-        boolean allCountIsOne = results.stream()
-                .allMatch(obj -> ((Long) obj[1]) == 1L);
-
-        List<ReportRawData.MostSelectedQuestionItem> topQuestions = new ArrayList<>();
-        for (Object[] row : results) {
-            String questionContent = (String) row[0];
-            int selectionCount = ((Number) row[1]).intValue();
-            topQuestions.add(new ReportRawData.MostSelectedQuestionItem(questionContent, selectionCount));
-        }
-
-        return new ReportRawData.MostSelectedQuestionRawData(year, month, allCountIsOne, topQuestions);
-    }
-
-    @Override
-    public ReportRawData.HourlyAnswerRawData getHourlyAnswerCountMap(int year, int month,  Long memberId) {
-        LocalDate startDate = DateUtil.getStartDate(year, month);
-        LocalDate endDate = DateUtil.getEndDate(year, month);
-
-        List<Object[]> results = answerHourStatRepository.findHourlyAnswerCountsByMemberIdAndDateRange(memberId, startDate, endDate);
-        if(results.isEmpty()) {
-            throw new ReportStatHandler(ErrorStatus.STATS_NOT_FOUND);
-        }
-
-        Map<Integer, Integer> hourCountMap = new HashMap<>();
-        for (Object[] row : results) {
-            int hour = ((Number) row[0]).intValue();
-            int count = ((Number) row[1]).intValue();
-            hourCountMap.put(hour, count);
-        }
-
-        for (int i = 0; i < 24; i++) {
-            hourCountMap.putIfAbsent(i, 0);
-        }
-
-        return new ReportRawData.HourlyAnswerRawData(year, month, hourCountMap);
+        return new ReportRawData.MonthlyReportRawData(year, month, questionListRaw, mostSelectedRaw, peakHourRaw);
     }
 
     @Override
@@ -120,5 +67,65 @@ public class ReportStatQueryServiceImpl implements ReportStatQueryService{
         LocalDateTime end = DateUtil.getEndDateTime(year, month);
 
         return postRepository.findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(member, start, end);
+    }
+
+
+    private ReportRawData.QuestionListRawData getQuestionList(int year, int month, Long memberId) {
+        List<MonthlyFixedQuestionStat> fixedQuestions = fixedQuestionRepository.findByMemberIdAndYearAndMonthOrderByQuestionOrder(
+                memberId, year, month);
+        if(fixedQuestions.isEmpty()) {
+            throw new ReportStatHandler(ErrorStatus.STATS_NOT_FOUND);
+        }
+
+        LocalDate start = DateUtil.getStartDate(year, month);
+        LocalDate end = DateUtil.getEndDate(year, month);
+
+        List<DailyRandomQuestionStat> randomQuestions = randomQuestionRepository.findByMemberIdAndSelectedDateRange(memberId, start, end);
+
+        return new ReportRawData.QuestionListRawData(fixedQuestions, randomQuestions);
+    }
+
+    private ReportRawData.MostSelectedQuestionRawData getMostSelectedQuestions(int year, int month, Long memberId) {
+        Pageable top3 = PageRequest.of(0, 3);
+
+        LocalDate startDate = DateUtil.getStartDate(year, month);
+        LocalDate endDate = DateUtil.getEndDate(year, month);
+
+        List<Object[]> results = randomQuestionRepository.findTop3QuestionsByMemberAndDateRange(memberId, startDate, endDate, top3);
+
+        boolean allCountIsOne = results.stream()
+                .allMatch(obj -> ((Long) obj[1]) == 1L);
+
+        List<ReportRawData.MostSelectedQuestionItem> topQuestions = new ArrayList<>();
+        for (Object[] row : results) {
+            String questionContent = (String) row[0];
+            int selectionCount = ((Number) row[1]).intValue();
+            topQuestions.add(new ReportRawData.MostSelectedQuestionItem(questionContent, selectionCount));
+        }
+
+        return new ReportRawData.MostSelectedQuestionRawData(allCountIsOne, topQuestions);
+    }
+
+    private ReportRawData.HourlyAnswerRawData getHourlyAnswerCountMap(int year, int month,  Long memberId) {
+        LocalDate startDate = DateUtil.getStartDate(year, month);
+        LocalDate endDate = DateUtil.getEndDate(year, month);
+
+        List<Object[]> results = answerHourStatRepository.findHourlyAnswerCountsByMemberIdAndDateRange(memberId, startDate, endDate);
+        if(results.isEmpty()) {
+            throw new ReportStatHandler(ErrorStatus.STATS_NOT_FOUND);
+        }
+
+        Map<Integer, Integer> hourCountMap = new HashMap<>();
+        for (Object[] row : results) {
+            int hour = ((Number) row[0]).intValue();
+            int count = ((Number) row[1]).intValue();
+            hourCountMap.put(hour, count);
+        }
+
+        for (int i = 0; i < 24; i++) {
+            hourCountMap.putIfAbsent(i, 0);
+        }
+
+        return new ReportRawData.HourlyAnswerRawData(hourCountMap);
     }
 }

--- a/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
+++ b/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
@@ -125,7 +125,14 @@ public class ReportStatConverter {
                 .build();
     }
 
-    public static ReportStatResponseDTO.MonthlyReportDTO toMonthlyReport(int year, int month, ReportRawData.QuestionListRawData questionListRaw, ReportRawData.MostSelectedQuestionRawData mostSelectedRaw, ReportRawData.HourlyAnswerRawData peakHourRaw) {
+    public static ReportStatResponseDTO.MonthlyReportDTO toMonthlyReport(ReportRawData.MonthlyReportRawData rawData) {
+
+        int year = rawData.getYear();
+        int month = rawData.getMonth();
+
+        ReportRawData.QuestionListRawData questionListRaw = rawData.getQuestionListRaw();
+        ReportRawData.MostSelectedQuestionRawData mostSelectedRaw = rawData.getMostSelectedRaw();
+        ReportRawData.HourlyAnswerRawData peakHourRaw = rawData.getPeakHourRaw();
 
         List<ReportStatResponseDTO.QuestionDTO> fixed = questionListRaw.getFixedQuestions().stream()
                 .map(stat -> ReportStatResponseDTO.QuestionDTO.builder()

--- a/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
+++ b/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
@@ -23,69 +23,6 @@ public class ReportStatConverter {
         throw new UnsupportedOperationException("Utility class");
     }
 
-    public static ReportStatResponseDTO.PeakHourDTO toPeakHourDTO(ReportRawData.HourlyAnswerRawData rawData) {
-        Map.Entry<Integer, Integer> maxEntry = rawData.getHourCountMap().entrySet().stream()
-                .max(Map.Entry.comparingByValue())
-                .orElse(null);
-
-        int topHour = (maxEntry != null) ? maxEntry.getKey() : -1;
-        int maxCount = (maxEntry != null) ? maxEntry.getValue() : -1;
-
-        ReportStatResponseDTO.HourlyAnswerCountDTO topHours = ReportStatResponseDTO.HourlyAnswerCountDTO.builder()
-                .hour(topHour)
-                .answerCount(maxCount)
-                .build();
-
-        List<ReportStatResponseDTO.TimeZoneCountDTO> timeZoneStats = Arrays.stream(TimeZoneType.values())
-                .map(type -> new ReportStatResponseDTO.TimeZoneCountDTO(
-                        type,
-                        getTimeZoneCount(type, rawData.getHourCountMap())
-                )).toList();
-
-        return ReportStatResponseDTO.PeakHourDTO.builder()
-                .year(rawData.getYear())
-                .month(rawData.getMonth())
-                .topHours(topHours)
-                .timeZoneStats(timeZoneStats)
-                .build();
-    }
-
-    public static ReportStatResponseDTO.MostSelectedQuestionDTO toMostSelectedQuestionDTO(ReportRawData.MostSelectedQuestionRawData rawData) {
-        List<ReportStatResponseDTO.SelectedQuestionDTO> questions = rawData.getQuestions().stream()
-                .map(data -> ReportStatResponseDTO.SelectedQuestionDTO.builder()
-                        .questionContent(data.getQuestionContent())
-                        .selectedCount(data.getSelectionCount())
-                        .build()
-                ).toList();
-
-        return ReportStatResponseDTO.MostSelectedQuestionDTO.builder()
-                .year(rawData.getYear())
-                .month(rawData.getMonth())
-                .questions(questions)
-                .build();
-    }
-
-    public static ReportStatResponseDTO.QuestionListDTO toQuestionListDTO(ReportRawData.QuestionListRawData rawData) {
-        List<ReportStatResponseDTO.QuestionDTO> fixed = rawData.getFixedQuestions().stream()
-                .map(stat -> ReportStatResponseDTO.QuestionDTO.builder()
-                        .questionContent(stat.getQuestionContent())
-                        .build()
-                ).toList();
-
-        List<ReportStatResponseDTO.QuestionDTO> random = rawData.getRandomQuestions().stream()
-                .map(stat -> ReportStatResponseDTO.QuestionDTO.builder()
-                        .questionContent(stat.getQuestionContent())
-                        .build()
-                ).toList();
-
-        return ReportStatResponseDTO.QuestionListDTO.builder()
-                .year(rawData.getYear())
-                .month(rawData.getMonth())
-                .fixedQuestions(fixed)
-                .randomQuestions(random)
-                .build();
-    }
-
     public static ReportStatResponseDTO.TopDailySelectionDTO toTopDailySelectionDTO(ReportRawData.DailyOptionRawData rawData) {
         List<ReportStatResponseDTO.DailyOptionDTO> optionDTOList = rawData.getTopSelectedOption().entrySet().stream()
                 .map(entry -> {
@@ -109,13 +46,6 @@ public class ReportStatConverter {
                 .month(rawData.getMonth())
                 .dailyList(optionDTOList)
                 .build();
-    }
-
-    private static int getTimeZoneCount(TimeZoneType type, Map<Integer, Integer> hourCountMap) {
-        return hourCountMap.entrySet().stream()
-                .filter(entry -> type.containsHour(entry.getKey()))
-                .mapToInt(Map.Entry::getValue)
-                .sum();
     }
 
     public static List<DailyAnswerHourStat> toDailyAnswerHourStats(List<Post> posts, LocalDate targetDate) {
@@ -192,6 +122,56 @@ public class ReportStatConverter {
 
         return ReportStatResponseDTO.DailyDetailListDTO.builder()
                 .dailyDetails(detailMap)
+                .build();
+    }
+
+    public static ReportStatResponseDTO.MonthlyReportDTO toMonthlyReport(int year, int month, ReportRawData.QuestionListRawData questionListRaw, ReportRawData.MostSelectedQuestionRawData mostSelectedRaw, ReportRawData.HourlyAnswerRawData peakHourRaw) {
+
+        List<ReportStatResponseDTO.QuestionDTO> fixed = questionListRaw.getFixedQuestions().stream()
+                .map(stat -> ReportStatResponseDTO.QuestionDTO.builder()
+                        .questionContent(stat.getQuestionContent())
+                        .build()
+                ).toList();
+
+        List<ReportStatResponseDTO.QuestionDTO> random = questionListRaw.getRandomQuestions().stream()
+                .map(DailyRandomQuestionStat::getQuestionContent)
+                .distinct()
+                .map(content -> ReportStatResponseDTO.QuestionDTO.builder()
+                        .questionContent(content)
+                        .build())
+                .toList();
+
+        boolean isAllOneCount = mostSelectedRaw.isAllOneCount();
+        List<ReportStatResponseDTO.SelectedQuestionDTO> mostSelected = Collections.emptyList();
+
+        if(!isAllOneCount){
+            mostSelected = mostSelectedRaw.getQuestions().stream()
+                    .map(data -> ReportStatResponseDTO.SelectedQuestionDTO.builder()
+                            .questionContent(data.getQuestionContent())
+                            .selectedCount(data.getSelectionCount())
+                            .build()
+                    ).toList();
+        }
+
+        TimeZoneType peakTime = peakHourRaw.getHourCountMap().entrySet().stream()
+                .collect(Collectors.groupingBy(
+                        e -> TimeZoneType.fromHour(e.getKey()),
+                        () -> new EnumMap<>(TimeZoneType.class),
+                        Collectors.summingInt(Map.Entry::getValue)
+                ))
+                .entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+
+        return ReportStatResponseDTO.MonthlyReportDTO.builder()
+                .year(year)
+                .month(month)
+                .fixedQuestions(fixed)
+                .randomQuestions(random)
+                .isAllOneCount(isAllOneCount)
+                .mostSelectedQuestions(mostSelected)
+                .peakTimeZone(peakTime)
                 .build();
     }
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/reportStat/DailyRandomQuestionStatRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/reportStat/DailyRandomQuestionStatRepository.java
@@ -14,7 +14,6 @@ import java.util.List;
 public interface DailyRandomQuestionStatRepository extends JpaRepository<DailyRandomQuestionStat, Long> {
 
     // 특정 월의 모든 랜덤 질문들을 날짜 순으로 조회
-    //TODO : 여기 지금 날짜순으로 정렬만 했는데, 만약 중복 질문은 X라면 수정해야 함
     @Query("SELECT d FROM DailyRandomQuestionStat d " +
             "WHERE d.memberId = :memberId " +
             "AND d.selectedDate BETWEEN :startDate AND :endDate " +

--- a/src/main/java/com/coredisc/presentation/controller/ReportStatController.java
+++ b/src/main/java/com/coredisc/presentation/controller/ReportStatController.java
@@ -1,6 +1,5 @@
 package com.coredisc.presentation.controller;
 
-import com.coredisc.application.service.reportStat.ReportRawData;
 import com.coredisc.application.service.reportStat.ReportStatQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.common.converter.ReportStatConverter;
@@ -24,11 +23,7 @@ public class ReportStatController implements ReportStatControllerDocs {
     // 사용자의 월별 리포트 조회
     @GetMapping
     public ApiResponse<ReportStatResponseDTO.MonthlyReportDTO> getMonthlyReport(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
-        ReportRawData.QuestionListRawData questionListRaw = reportStatQueryService.getQuestionList(year, month, member.getId());
-        ReportRawData.MostSelectedQuestionRawData mostSelectedRaw = reportStatQueryService.getMostSelectedQuestions(year, month, member.getId());
-        ReportRawData.HourlyAnswerRawData peakHourRaw = reportStatQueryService.getHourlyAnswerCountMap(year, month, member.getId());
-
-        return ApiResponse.onSuccess(ReportStatConverter.toMonthlyReport(year, month, questionListRaw, mostSelectedRaw, peakHourRaw));
+        return ApiResponse.onSuccess(ReportStatConverter.toMonthlyReport(reportStatQueryService.getMonthlyReportRawData(year, month, member.getId())));
     }
 
     // 사용자의 선택형 일기 리포트 조회(1) - 가장 많이 선택한 옵션 조회

--- a/src/main/java/com/coredisc/presentation/controller/ReportStatController.java
+++ b/src/main/java/com/coredisc/presentation/controller/ReportStatController.java
@@ -1,5 +1,6 @@
 package com.coredisc.presentation.controller;
 
+import com.coredisc.application.service.reportStat.ReportRawData;
 import com.coredisc.application.service.reportStat.ReportStatQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.common.converter.ReportStatConverter;
@@ -20,31 +21,23 @@ public class ReportStatController implements ReportStatControllerDocs {
 
     private final ReportStatQueryService reportStatQueryService;
 
-    // 사용자가 특정 달에 선택한 고정 질문 3개와 랜덤 질문 목록 조회
-    @GetMapping("/question-list")
-    public ApiResponse<ReportStatResponseDTO.QuestionListDTO> getMonthlyQuestionList(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
-        return ApiResponse.onSuccess(ReportStatConverter.toQuestionListDTO(reportStatQueryService.getQuestionList(year, month, member.getId())));
+    // 사용자의 월별 리포트 조회
+    @GetMapping
+    public ApiResponse<ReportStatResponseDTO.MonthlyReportDTO> getMonthlyReport(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
+        ReportRawData.QuestionListRawData questionListRaw = reportStatQueryService.getQuestionList(year, month, member.getId());
+        ReportRawData.MostSelectedQuestionRawData mostSelectedRaw = reportStatQueryService.getMostSelectedQuestions(year, month, member.getId());
+        ReportRawData.HourlyAnswerRawData peakHourRaw = reportStatQueryService.getHourlyAnswerCountMap(year, month, member.getId());
+
+        return ApiResponse.onSuccess(ReportStatConverter.toMonthlyReport(year, month, questionListRaw, mostSelectedRaw, peakHourRaw));
     }
 
-    // 사용자가 특정 달 동안 가장 많이 선택한 랜덤 질문 3개 조회
-    @GetMapping("/most-selected")
-    public ApiResponse<ReportStatResponseDTO.MostSelectedQuestionDTO> getMostSelectedQuestions(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
-        return ApiResponse.onSuccess(ReportStatConverter.toMostSelectedQuestionDTO(reportStatQueryService.getMostSelectedQuestions(year, month, member.getId())));
-    }
-
-    // 사용자가 특정 달에 시간대 별로 응답한 횟수 조회
-    @GetMapping("/peak-hours")
-    public ApiResponse<ReportStatResponseDTO.PeakHourDTO> getPeakHour(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
-        return ApiResponse.onSuccess(ReportStatConverter.toPeakHourDTO(reportStatQueryService.getHourlyAnswerCountMap(year, month, member.getId())));
-    }
-
-    // 사용자가 선택형 일기에서 특정 달에 가장 많이 선택한 옵션 조회
+    // 사용자의 선택형 일기 리포트 조회(1) - 가장 많이 선택한 옵션 조회
     @GetMapping("/daily/top-selection")
     public ApiResponse<ReportStatResponseDTO.TopDailySelectionDTO> getMostSelectedDaily(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
         return ApiResponse.onSuccess(ReportStatConverter.toTopDailySelectionDTO(reportStatQueryService.getMostSelectedDaily(year, month, member.getId())));
     }
 
-    // 사용자가 특정 달에 작성한 일기 내용 전체 출력
+    // 사용자의 선택형 일기 리포트 조회(2) - 일기 내용 전체 출력
     @GetMapping("/daily/details")
     public ApiResponse<ReportStatResponseDTO.DailyDetailListDTO> getDailyDetail(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
         return ApiResponse.onSuccess(ReportStatConverter.toDailyDetailListDTO(reportStatQueryService.getDailyDetails(year, month, member)));

--- a/src/main/java/com/coredisc/presentation/controllerdocs/ReportStatControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/ReportStatControllerDocs.java
@@ -9,25 +9,18 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "리포트 세부 통계", description = "사용자별 세부 통계 API")
+@Tag(name = "Monthly Report", description = "사용자의 월별 리포트 API")
 public interface ReportStatControllerDocs {
 
-    @Operation(summary = "기간별 전체 질문 목록 조회", description = "사용자가 특정 달에 선택한 고정 질문 3개와 랜덤 질문 목록을 조회합니다.")
-    ApiResponse<ReportStatResponseDTO.QuestionListDTO> getMonthlyQuestionList(
+    @Operation(summary = "사용자의 월별 리포트 조회", description = "특정 기간 동안 사용자의 활동에 대한 월별 리포트를 조회합니다.")
+    ApiResponse<ReportStatResponseDTO.MonthlyReportDTO> getMonthlyReport(
             @RequestParam("year") int year,
             @RequestParam("month") int month,
             @Parameter(hidden = true) @CurrentMember Member member
     );
 
-    @Operation(summary = "기간별 최다 선택된 랜덤 질문 3순위 조회", description = "사용자가 특정 달 동안 가장 많이 선택한 랜덤 질문 3개를 조회합니다.")
-    ApiResponse<ReportStatResponseDTO.MostSelectedQuestionDTO> getMostSelectedQuestions(
-            @RequestParam("year") int year,
-            @RequestParam("month") int month,
-            @Parameter(hidden = true) @CurrentMember Member member
-    );
-
-    @Operation(summary = "기간별 응답 시간대 횟수 조회", description = "사용자의 특정 월(startDate~endDate)에 가장 많이 답변한 시간대와 시간대별 응답 수 리스트를 조회합니다.")
-    ApiResponse<ReportStatResponseDTO.PeakHourDTO> getPeakHour(
+    @Operation(summary = "사용자가 특정 달에 작성한 일기 내용 전체 출력", description = "특정 기간 동안 일기 게시글의 daily_ 항목 중 가장 많이 선택된 옵션을 조회합니다.")
+    ApiResponse<ReportStatResponseDTO.DailyDetailListDTO> getDailyDetail(
             @RequestParam("year") int year,
             @RequestParam("month") int month,
             @Parameter(hidden = true) @CurrentMember Member member
@@ -40,10 +33,5 @@ public interface ReportStatControllerDocs {
             @Parameter(hidden = true) @CurrentMember Member member
     );
 
-    @Operation(summary = "사용자가 특정 달에 작성한 일기 내용 전체 출력", description = "특정 기간 동안 일기 게시글의 daily_ 항목 중 가장 많이 선택된 옵션을 조회합니다.")
-    ApiResponse<ReportStatResponseDTO.DailyDetailListDTO> getDailyDetail(
-            @RequestParam("year") int year,
-            @RequestParam("month") int month,
-            @Parameter(hidden = true) @CurrentMember Member member
-    );
+
 }

--- a/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatRequestDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatRequestDTO.java
@@ -1,4 +1,0 @@
-package com.coredisc.presentation.dto.reportStat;
-
-public class ReportStatRequestDTO {
-}

--- a/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatResponseDTO.java
@@ -1,6 +1,7 @@
 package com.coredisc.presentation.dto.reportStat;
 
 import com.coredisc.domain.common.enums.TimeZoneType;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -9,36 +10,21 @@ import java.util.Map;
 
 public class ReportStatResponseDTO {
 
+    @JsonPropertyOrder({
+            "year", "month", "fixedQuestions", "randomQuestions", "allOneCount", "mostSelectedQuestions", "peakTimeZone"
+    })
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PeakHourDTO{ //최다 답변 시간대
+    public static class MonthlyReportDTO{ // 월별 리포트 - 기본 화면
         private int year;
         private int month;
-        private HourlyAnswerCountDTO topHours;
-        private List<TimeZoneCountDTO> timeZoneStats;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class MostSelectedQuestionDTO{ //최다 선택한 랜덤 질문
-        private int year;
-        private int month;
-        private List<SelectedQuestionDTO> questions;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class QuestionListDTO{ //월별 전체 질문 리스트
-        private int year;
-        private int month;
-        private List<QuestionDTO> fixedQuestions; // 혹시 추가로 필요한 내용 있을까봐 따로 dto 만들었는데, 없으면 String으로 수정할 예정
+        private List<QuestionDTO> fixedQuestions;
         private List<QuestionDTO> randomQuestions;
+        private boolean isAllOneCount;
+        private List<SelectedQuestionDTO> mostSelectedQuestions;
+        private TimeZoneType peakTimeZone;
     }
 
     @Builder
@@ -58,24 +44,6 @@ public class ReportStatResponseDTO {
     @Setter
     public static class DailyDetailListDTO{
         private Map<LocalDate, String> dailyDetails;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class HourlyAnswerCountDTO{ //시간대별 응답수 -> 시간 단위
-        private int hour;
-        private int answerCount;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class TimeZoneCountDTO{ //시간대별 응답수 -> 단어 단위
-        private TimeZoneType timeZone;
-        private int answerCount;
     }
 
     @Builder


### PR DESCRIPTION
## 💡 작업 내용 요약
프론트 측에서 조금 더 편하게 조회할 수 있도록
기존에 3개로 나누어져 있던 각각의 세부 통계 조회 API를 하나로 통합했습니다. (질문 목록+최다시간대+최다 선택 랜덤 질문)
(선택형 일기에 대한 리포트는 그대로 2개로 나누어서 유지합니다.) 

또한 기존에는 응답 시간대를 조회할 때 각 시간대별 응답 횟수와 최다 응답시간을 함께 반환한 반면,
바뀐 DTO에서는 최다 응답 시간대의 enum만 리턴합니다. 

isAllOneCount 항목은 모두 다른 랜덤 질문을 선택했을 경우 true로 처리하고
해당 항목이 true인 경우에는 mostSelectedQuestions 을 빈 리스트로 반환합니다. 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #115 

## 📎 기타 참고사항

