### PR TITLE
Feat : 질문 즐겨찾기 관련 API

### DIFF
--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandService.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandService.java
@@ -35,7 +35,10 @@ public interface QuestionCommandService {
     // 저장헀던 공유 질문을 삭제
     void deleteMemberOfficialQuestion(Member member, Long questionId);
 
-    // 즐겨찾기 추가
+    // 타사용자 공유질문 즐겨찾기 추가
     QuestionResponseDTO.UpdateSavedSharedQuestionFavoriteStatusResultDTO updateSavedSharedQuestionFavoriteStatus(Member member, Long questionId, Boolean isFavorite);
+
+    // 내 공유 질문 즐겨찾기 추가
+    QuestionResponseDTO.UpdateMySharedQuestionFavoriteStatusResultDTO updateMySharedQuestionFavoriteStatus(Member member, Long questionId, Boolean isFavorite);
 
 }

--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
@@ -254,7 +254,7 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
         memberOfficialQuestionRepository.delete(memberOfficialQuestion);
     }
 
-    // 즐겨찾기 추가
+    // 타사용자 공유 질문 즐겨찾기 추가
     @Override
     @Transactional
     public QuestionResponseDTO.UpdateSavedSharedQuestionFavoriteStatusResultDTO updateSavedSharedQuestionFavoriteStatus(Member member, Long questionId, Boolean isFavorite) {
@@ -279,4 +279,29 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
         return QuestionConverter.toUpdateSavedSharedQuestionFavoriteStatusResultDTO(memberOfficialQuestionRepository.save(memberOfficialQuestion));
     }
 
+    // 내 공유질문 즐겨찾기 추가
+    @Override
+    @Transactional
+    public QuestionResponseDTO.UpdateMySharedQuestionFavoriteStatusResultDTO updateMySharedQuestionFavoriteStatus(Member member, Long questionId, Boolean isFavorite) {
+
+        OfficialQuestion officialQuestion = officialQuestionRepository.findById(questionId)
+                .orElseThrow(() -> new QuestionHandler(ErrorStatus.OFFICIAL_QUESTION_NOT_FOUND));
+
+        // 작성자 일치 여부
+        if (!member.equals(officialQuestion.getMember()))
+            throw new QuestionHandler(ErrorStatus.CANNOT_FAVORITE_OTHERS_QUESTION);
+
+        // 이미 즐겨찾기 추가한 상태
+        if (officialQuestion.getIsFavorite() && isFavorite)
+            throw new QuestionHandler(ErrorStatus.ALREADY_FAVORITE_OFFICIAL_QUESTION);
+
+        // 이미 즐겨찾기 삭제한 상태
+        if (!officialQuestion.getIsFavorite() && !isFavorite)
+            throw new QuestionHandler(ErrorStatus.ALREADY_NOT_FAVORITE_OFFICIAL_QUESTION);
+
+
+        officialQuestion.updateFavorite(isFavorite);
+
+        return QuestionConverter.toUpdateMySharedQuestionFavoriteStatusResultDTO(officialQuestionRepository.save(officialQuestion));
+    }
 }

--- a/src/main/java/com/coredisc/application/service/question/QuestionQueryService.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionQueryService.java
@@ -31,6 +31,9 @@ public interface QuestionQueryService {
             int pageSize);
 
 
+    // 내가 발행한 공유질문 리스트 조회 (개수 포함 ver)
+    QuestionResponseDTO.MySharedQuestionPreviewListResultDTO getMySharedQuestionPreviewList(Member member, Long cursorId, int pageSize);
+
     // 내가 발행한 공유질문 리스트 조회 (카테고리 필터링 포함)
     CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO> getMySharedQuestionList(Member member, Long categoryId, Boolean favorite, Long cursorId, int pageSize);
 

--- a/src/main/java/com/coredisc/application/service/question/QuestionQueryService.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionQueryService.java
@@ -32,7 +32,7 @@ public interface QuestionQueryService {
 
 
     // 내가 발행한 공유질문 리스트 조회 (카테고리 필터링 포함)
-    QuestionResponseDTO.MySharedQuestionListResultDTO getMySharedQuestionList(Member member, Long categoryId, Long cursorId, int pageSize);
+    CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO> getMySharedQuestionList(Member member, Long categoryId, Boolean favorite, Long cursorId, int pageSize);
 
     // 선택한 고정&랜덤 질문 조회
     List<QuestionResponseDTO.SelectedTodayQuestionResultDTO> getMyTodayQuestion(Member member);

--- a/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
@@ -66,15 +66,20 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
         return customQuestionRepository.findBasicQuestionListByKeyword(member.getId(), keyword, cursorCreatedAt, cursorQuestionType, cursorId, pageSize);
     }
 
-    // 내가 발행한 공유 질문 리스트 조회
+    // 내가 발행한 공유 질문 리스트 조회 (카테고리 필터링 포함)
     @Override
-    public QuestionResponseDTO.MySharedQuestionListResultDTO getMySharedQuestionList(Member member, Long categoryId, Long cursorId, int pageSize){
+    public CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO> getMySharedQuestionList(Member member, Long categoryId, Boolean favorite, Long cursorId, int pageSize){
 
-        Long mySharedQuestionTotal = officialQuestionRepository.countOfficialQuestionByMember(member);
+        if (Boolean.TRUE.equals(favorite)  && categoryId != null) {   // 즐겨찾기랑 카테고리 동시 필터링 방지
+            throw new QuestionHandler(ErrorStatus.INVALID_OFFICIAL_QUESTION_FILTER_COMBINATION);
+        }
 
         List<OfficialQuestion> mySharedQuestionsList;
 
-        if (categoryId == null || categoryId == 0) {    // 전체 조회
+        if (Boolean.TRUE.equals(favorite)) {    // 즐겨찾기
+            mySharedQuestionsList = officialQuestionRepository.findFavoritesByMember(member, cursorId, pageSize);
+        }
+        else if (categoryId == null || categoryId == 0) {    // 전체 조회
             mySharedQuestionsList = officialQuestionRepository.findAllByMemberAndCursor(member, cursorId, pageSize);
         } else {    // 카테고리별 조회
             Category category = categoryRepository.findById(categoryId)
@@ -96,13 +101,7 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
                         })
                         .toList();
 
-        CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO> cursorDTO =
-                new CursorDTO<>(mySharedQuestionDTOList, hasNext);
-
-        return QuestionResponseDTO.MySharedQuestionListResultDTO.builder()
-                .mySharedQuestionCnt(mySharedQuestionTotal)
-                .mySharedQuestionList(cursorDTO)
-                .build();
+        return new CursorDTO<>(mySharedQuestionDTOList, hasNext);
     }
 
     // 선택한 고정&랜덤 질문 조회
@@ -143,7 +142,7 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
             int pageSize) {
 
         if (Boolean.TRUE.equals(favorite)  && categoryId != null) {   // 즐겨찾기랑 카테고리 동시 필터링 방지
-            throw new QuestionHandler(ErrorStatus.INVALID_SAVED_OFFICIAL_QUESTION_FILTER_COMBINATION);
+            throw new QuestionHandler(ErrorStatus.INVALID_OFFICIAL_QUESTION_FILTER_COMBINATION);
         }
 
         List<MemberOfficialQuestion> mySavedSharedQuestionList;

--- a/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
@@ -66,6 +66,37 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
         return customQuestionRepository.findBasicQuestionListByKeyword(member.getId(), keyword, cursorCreatedAt, cursorQuestionType, cursorId, pageSize);
     }
 
+    // 내가 발행한 공유질문 리스트 조회 (개수 포함 ver)
+    @Override
+    public QuestionResponseDTO.MySharedQuestionPreviewListResultDTO getMySharedQuestionPreviewList(Member member, Long cursorId, int pageSize) {
+
+        Long mySharedQuestionTotal = officialQuestionRepository.countOfficialQuestionByMember(member);
+
+        List<OfficialQuestion> mySharedQuestionsList = officialQuestionRepository.findAllByMemberAndCursor(member, cursorId, pageSize);
+
+        boolean hasNext = mySharedQuestionsList.size() > pageSize;
+
+        if (hasNext) {
+            mySharedQuestionsList = mySharedQuestionsList.subList(0, pageSize);
+        }
+
+        List<QuestionResponseDTO.MySharedQuestionPreviewResultDTO> mySharedQuestionDTOList =
+                mySharedQuestionsList.stream()
+                        .map(question -> {
+                            long sharedCount = memberOfficialQuestionRepository.countByOfficialQuestion(question);
+                            return QuestionConverter.toMySharedQuestionPreviewResultDTO(question, sharedCount);
+                        })
+                        .toList();
+
+        CursorDTO<QuestionResponseDTO.MySharedQuestionPreviewResultDTO> cursorDTO =
+                new CursorDTO<>(mySharedQuestionDTOList, hasNext);
+
+        return QuestionResponseDTO.MySharedQuestionPreviewListResultDTO.builder()
+                .mySharedQuestionCnt(mySharedQuestionTotal)
+                .mySharedQuestionList(cursorDTO)
+                .build();
+    }
+
     // 내가 발행한 공유 질문 리스트 조회 (카테고리 필터링 포함)
     @Override
     public CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO> getMySharedQuestionList(Member member, Long categoryId, Boolean favorite, Long cursorId, int pageSize){

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -104,6 +104,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_OFFICIAL_QUESTION_FILTER_COMBINATION(HttpStatus.BAD_REQUEST, "QUESTION4012", "카테고리와 즐겨찾기 필터는 동시에 사용할 수 없습니다. (favorite=true면 categoryId는 넘기지 말아야 함, categoryId 넘길 시 favorite는 안넘기거나 false여야 함)"),
     ALREADY_FAVORITE_OFFICIAL_QUESTION(HttpStatus.BAD_REQUEST, "QUESTION4013", "이미 즐겨찾기된 질문입니다."),
     ALREADY_NOT_FAVORITE_OFFICIAL_QUESTION(HttpStatus.BAD_REQUEST, "QUESTION4014", "즐겨찾기가 되어있지 않은 질문입니다."),
+    CANNOT_FAVORITE_OTHERS_QUESTION(HttpStatus.FORBIDDEN, "QUESTION4015", "자신이 작성한 질문만 즐겨찾기 할 수 있습니다."),
 
     // Follow 관련 에러
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW4001", "자기 자신은 팔로우할 수 없습니다."),

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -101,7 +101,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CANNOT_SELECT_OWN_OFFICIAL_QUESTION(HttpStatus.FORBIDDEN, "QUESTION4009", "자신이 작성한 공유 질문은 저장할 수 없습니다."),
     MEMBER_OFFICIAL_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION4010", "저장한 공유 질문이 존재하지 않습니다."),
     ALREADY_SAVED_OFFICIAL_QUESTION(HttpStatus.BAD_REQUEST, "QUESTION4011", "이미 해당 공유 질문을 저장했습니다."),
-    INVALID_SAVED_OFFICIAL_QUESTION_FILTER_COMBINATION(HttpStatus.BAD_REQUEST, "QUESTION4012", "카테고리와 즐겨찾기 필터는 동시에 사용할 수 없습니다. (favorite=true면 categoryId는 넘기지 말아야 함, categoryId 넘길 시 favorite는 안넘기거나 false여야 함)"),
+    INVALID_OFFICIAL_QUESTION_FILTER_COMBINATION(HttpStatus.BAD_REQUEST, "QUESTION4012", "카테고리와 즐겨찾기 필터는 동시에 사용할 수 없습니다. (favorite=true면 categoryId는 넘기지 말아야 함, categoryId 넘길 시 favorite는 안넘기거나 false여야 함)"),
     ALREADY_FAVORITE_OFFICIAL_QUESTION(HttpStatus.BAD_REQUEST, "QUESTION4013", "이미 즐겨찾기된 질문입니다."),
     ALREADY_NOT_FAVORITE_OFFICIAL_QUESTION(HttpStatus.BAD_REQUEST, "QUESTION4014", "즐겨찾기가 되어있지 않은 질문입니다."),
 

--- a/src/main/java/com/coredisc/common/converter/QuestionConverter.java
+++ b/src/main/java/com/coredisc/common/converter/QuestionConverter.java
@@ -63,6 +63,7 @@ public class QuestionConverter {
                 .categories(categories)
                 .question(question.getContents())
                 .sharedCount(sharedCount)
+                .isFavorite(question.getIsFavorite())
                 .createdAt(question.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/coredisc/common/converter/QuestionConverter.java
+++ b/src/main/java/com/coredisc/common/converter/QuestionConverter.java
@@ -50,6 +50,23 @@ public class QuestionConverter {
                 .build();
     }
 
+    public static QuestionResponseDTO.MySharedQuestionPreviewResultDTO toMySharedQuestionPreviewResultDTO(OfficialQuestion question, long sharedCount) {
+        List<CategoryResponseDTO.CategoryInfoDTO> categories = question.getQuestionCategoryList().stream()
+                .map(qc -> CategoryResponseDTO.CategoryInfoDTO.builder()
+                        .categoryId(qc.getCategory().getId())
+                        .categoryName(qc.getCategory().getName())
+                        .build())
+                .toList();
+
+        return QuestionResponseDTO.MySharedQuestionPreviewResultDTO.builder()
+                .id(question.getId())
+                .categories(categories)
+                .question(question.getContents())
+                .sharedCount(sharedCount)
+                .createdAt(question.getCreatedAt())
+                .build();
+    }
+
     public static QuestionResponseDTO.MySharedQuestionResultDTO toMySharedQuestionResultDTO(OfficialQuestion question, long sharedCount) {
         List<CategoryResponseDTO.CategoryInfoDTO> categories = question.getQuestionCategoryList().stream()
                 .map(qc -> CategoryResponseDTO.CategoryInfoDTO.builder()

--- a/src/main/java/com/coredisc/common/converter/QuestionConverter.java
+++ b/src/main/java/com/coredisc/common/converter/QuestionConverter.java
@@ -229,4 +229,12 @@ public class QuestionConverter {
                 .createdAt(memberOfficialQuestion.getCreatedAt())
                 .build();
     }
+
+    public static QuestionResponseDTO.UpdateMySharedQuestionFavoriteStatusResultDTO toUpdateMySharedQuestionFavoriteStatusResultDTO(OfficialQuestion officialQuestion) {
+
+        return QuestionResponseDTO.UpdateMySharedQuestionFavoriteStatusResultDTO.builder()
+                .id(officialQuestion.getId())
+                .createdAt(officialQuestion.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestion.java
+++ b/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestion.java
@@ -41,4 +41,9 @@ public class OfficialQuestion extends BaseEntity {
 
     @OneToMany(mappedBy = "officialQuestion")
     private List<TodayQuestion> todayQuestionList = new ArrayList<>();
+
+    public void updateFavorite(boolean isFavorite) {
+        this.isFavorite = isFavorite;
+    }
+
 }

--- a/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestion.java
+++ b/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestion.java
@@ -25,6 +25,10 @@ public class OfficialQuestion extends BaseEntity {
     @Builder.Default    // false: 기본질문, true: 공유질문
     private boolean isShared = true;
 
+    @Column(nullable = false)   // 즐겨찾기. false = 즐겨찾기 안함, true = 즐겨찾기 함
+    @Builder.Default
+    private Boolean isFavorite = false;
+
     @Column(nullable = false)
     private String contents;
 

--- a/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestionRepository.java
@@ -15,6 +15,8 @@ public interface OfficialQuestionRepository {
 
     OfficialQuestion save(OfficialQuestion officialQuestion);
 
+    List<OfficialQuestion> findFavoritesByMember(Member member, Long cursorId, int pageSize);
+
     List<OfficialQuestion> findAllByMemberAndCursor(Member member, Long cursorId, int pageSize);
 
     List<OfficialQuestion> findAllByMemberAndCategory(Member member, Category category, Long cursorId, int pageSize);

--- a/src/main/java/com/coredisc/infrastructure/repository/question/OfficialQuestionRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/OfficialQuestionRepositoryAdapter.java
@@ -29,6 +29,11 @@ public class OfficialQuestionRepositoryAdapter implements OfficialQuestionReposi
     }
 
     @Override
+    public List<OfficialQuestion> findFavoritesByMember(Member member, Long cursorId, int pageSize) {
+        return queryOfficialQuestionRepository.findFavoritesByMember(member, cursorId, pageSize);
+    }
+
+    @Override
     public List<OfficialQuestion> findAllByMemberAndCursor(Member member, Long cursorId, int pageSize){
         return queryOfficialQuestionRepository.findAllByMemberAndCursor(member, cursorId, pageSize);
     }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/querydsl/QueryOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/querydsl/QueryOfficialQuestionRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 public interface QueryOfficialQuestionRepository {
 
+    List<OfficialQuestion> findFavoritesByMember(Member member, Long cusorId, int pageSize);
+
     List<OfficialQuestion> findAllByMemberAndCursor(Member member, Long cursorId, int pageSize);
 
     List<OfficialQuestion> findAllByMemberAndCategory(Member member, Category category, Long cursorId, int pageSize);

--- a/src/main/java/com/coredisc/infrastructure/repository/question/querydsl/QueryOfficialQuestionRepositoryImpl.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/querydsl/QueryOfficialQuestionRepositoryImpl.java
@@ -31,6 +31,21 @@ public class QueryOfficialQuestionRepositoryImpl implements QueryOfficialQuestio
 
     private final QMemberOfficialQuestion qMemberOfficialQuestion = QMemberOfficialQuestion.memberOfficialQuestion;
 
+
+    @Override
+    public List<OfficialQuestion> findFavoritesByMember(Member member, Long cusorId, int pageSize) {
+        return jpaQueryFactory
+                .selectFrom(qOfficialQuestion)
+                .where(qOfficialQuestion.member.eq(member),
+                        qOfficialQuestion.isFavorite.isTrue(),
+                        cusorId != null ? qOfficialQuestion.id.lt(cusorId) : null
+                )
+                .orderBy(qOfficialQuestion.id.desc())
+                .limit(pageSize + 1)
+                .fetch();
+    }
+
+    @Override
     public List<OfficialQuestion> findAllByMemberAndCursor(Member member, Long cursorId, int pageSize) {
         BooleanExpression cursorCondition = null;
 

--- a/src/main/java/com/coredisc/presentation/controller/QuestionController.java
+++ b/src/main/java/com/coredisc/presentation/controller/QuestionController.java
@@ -86,16 +86,17 @@ public class QuestionController implements QuestionControllerDocs {
 
     // 내가 발행한 공유 질문 리스트 조회 (카테고리 구분 포함)
     @GetMapping("/official/mine")
-    public ApiResponse<QuestionResponseDTO.MySharedQuestionListResultDTO> getMySharedQuestionList(
+    public ApiResponse<CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO>> getMySharedQuestionList(
             @CurrentMember Member member,
             @RequestParam(name = "categoryId", required = false) Long categoryId,
+            @RequestParam(name = "favorite", required = false) Boolean favorite,
             @RequestParam(name = "cursorId", required = false) Long cursorId,
             @RequestParam(name = "size", required = false) Integer size) {
 
         if (size == null)
             size = DEFAULT_PAGE_SIZE;
 
-        return ApiResponse.onSuccess(questionQueryService.getMySharedQuestionList(member, categoryId, cursorId, size));
+        return ApiResponse.onSuccess(questionQueryService.getMySharedQuestionList(member, categoryId, favorite, cursorId, size));
 
     }
 

--- a/src/main/java/com/coredisc/presentation/controller/QuestionController.java
+++ b/src/main/java/com/coredisc/presentation/controller/QuestionController.java
@@ -84,6 +84,19 @@ public class QuestionController implements QuestionControllerDocs {
         return ApiResponse.onSuccess( questionQueryService.getBasicQuestionSearchList(member, keyword, cursorCreatedAt, cursorQuestionType, cursorId, size) );
     }
 
+    // 내가 발행한 공유 질문 리스트 조회 (개수 포함 ver)
+    @GetMapping("/official/mine/preview")
+    public ApiResponse<QuestionResponseDTO.MySharedQuestionPreviewListResultDTO> getMySharedQuestionListPreview(
+            @CurrentMember Member member,
+            @RequestParam(name = "cursorId", required = false) Long cursorId,
+            @RequestParam(name = "size", required = false) Integer size) {
+
+        if (size == null)
+            size = DEFAULT_PAGE_SIZE;
+
+        return ApiResponse.onSuccess(questionQueryService.getMySharedQuestionPreviewList(member, cursorId, size));
+    }
+
     // 내가 발행한 공유 질문 리스트 조회 (카테고리 구분 포함)
     @GetMapping("/official/mine")
     public ApiResponse<CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO>> getMySharedQuestionList(

--- a/src/main/java/com/coredisc/presentation/controller/QuestionController.java
+++ b/src/main/java/com/coredisc/presentation/controller/QuestionController.java
@@ -187,11 +187,18 @@ public class QuestionController implements QuestionControllerDocs {
         return ApiResponse.onSuccess( questionQueryService.getPopularQuestionList() );
     }
 
-    // 즐겨찾기 추가
+    // 타 사용자 공유질문 즐겨찾기 추가
     @PatchMapping("/official/{questionId}/favorite")
     public ApiResponse<QuestionResponseDTO.UpdateSavedSharedQuestionFavoriteStatusResultDTO> updateSavedSharedQuestionFavoriteStatus(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId, @RequestParam(name = "isFavorite") Boolean isFavorite) {
 
         return ApiResponse.onSuccess( questionCommandService.updateSavedSharedQuestionFavoriteStatus(member, questionId, isFavorite) );
+    }
+
+    // 내 공유 질문 즐겨찾기 추가
+    @PatchMapping("/official/mine/{questionId}/favorite")
+    public ApiResponse<QuestionResponseDTO.UpdateMySharedQuestionFavoriteStatusResultDTO> updateMySharedQuestionFavoriteStatus(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId, @RequestParam(name = "isFavorite") Boolean isFavorite) {
+
+        return ApiResponse.onSuccess( questionCommandService.updateMySharedQuestionFavoriteStatus(member, questionId, isFavorite) );
     }
 
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
@@ -133,7 +133,7 @@ public interface QuestionControllerDocs {
     @Operation(summary = "인기 질문 목록 조회", description = "인기 질문 상위 5개를 조회하는 기능입니다.")
     ApiResponse<QuestionResponseDTO.PopularQuestionListResultDTO> getPopularQuestionList(@CurrentMember Member member);
 
-    @Operation(summary = "저장한 공유 질문 즐겨찾기 추가/삭제", description = "타사용자가 발행하여 저장헀던 공유 질문을 즐겨찾기에 추가/삭제하는 기능입니다.")
+    @Operation(summary = "저장한 타사용자의 공유 질문 즐겨찾기 추가/삭제", description = "타사용자가 발행하여 저장헀던 공유 질문을 즐겨찾기에 추가/삭제하는 기능입니다.")
     @Parameters({
             @Parameter(name = "questionId", description = "질문ID pathVariable입니다."),
             @Parameter(name = "isFavorite", description = "즐겨찾기 추가/삭제 (true: 추가, false: 삭제)"),

--- a/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
@@ -59,6 +59,16 @@ public interface QuestionControllerDocs {
             @RequestParam(name = "cursorId", required = false) Long cursorId,
             @RequestParam(name = "size", required = false) Integer size);
 
+    @Operation(summary = "내가 현재 발행한 공유질문 리스트 조회 (발행 개수 포함 ver)", description = "사용자 현재 본인이 발행한 공유질문 리스트를 조회하는 기능입니다. (발행 개수 포함 ver)")
+    @Parameters({
+            @Parameter(name = "cursorId", description = "커서 - 마지막 질문 ID, 첫 요청 때는 null"),
+            @Parameter(name = "size", description = "한 페이지당 조회할 질문 수, 기본값 10", required = false),
+    })
+    ApiResponse<QuestionResponseDTO.MySharedQuestionPreviewListResultDTO> getMySharedQuestionListPreview(
+            @CurrentMember Member member,
+            @RequestParam(name = "cursorId", required = false) Long cursorId,
+            @RequestParam(name = "size", required = false) Integer size);
+
     @Operation(summary = "내가 발행한 공유질문 리스트 조회 (카테고리 필터링 ver)", description = "사용자 본인이 발행한 공유질문 리스트를 조회하는 기능입니다. (카테고리 필터링 ver)")
     @Parameters({
             @Parameter(name = "categoryId", description = "카테고리ID입니다. (0 또는 생략 시 전체 조회)"),

--- a/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
@@ -133,10 +133,18 @@ public interface QuestionControllerDocs {
     @Operation(summary = "인기 질문 목록 조회", description = "인기 질문 상위 5개를 조회하는 기능입니다.")
     ApiResponse<QuestionResponseDTO.PopularQuestionListResultDTO> getPopularQuestionList(@CurrentMember Member member);
 
-    @Operation(summary = "저장한 타사용자의 공유 질문 즐겨찾기 추가/삭제", description = "타사용자가 발행하여 저장헀던 공유 질문을 즐겨찾기에 추가/삭제하는 기능입니다.")
+    @Operation(summary = "저장한 타사용자의 공유 질문 즐겨찾기 추가/삭제", description = "타사용자가 발행하여 저장했던 공유 질문을 즐겨찾기에 추가/삭제하는 기능입니다.")
     @Parameters({
             @Parameter(name = "questionId", description = "질문ID pathVariable입니다."),
             @Parameter(name = "isFavorite", description = "즐겨찾기 추가/삭제 (true: 추가, false: 삭제)"),
     })
     ApiResponse<QuestionResponseDTO.UpdateSavedSharedQuestionFavoriteStatusResultDTO> updateSavedSharedQuestionFavoriteStatus(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId, @RequestParam(name = "isFavorite") Boolean isFavorite);
+
+
+    @Operation(summary = "내가 공유 질문 즐겨찾기 추가/삭제", description = "내가 작성한 공유 질문을 즐겨찾기에 추가/삭제하는 기능입니다.")
+    @Parameters({
+            @Parameter(name = "questionId", description = "질문ID pathVariable입니다."),
+            @Parameter(name = "isFavorite", description = "즐겨찾기 추가/삭제 (true: 추가, false: 삭제)"),
+    })
+    ApiResponse<QuestionResponseDTO.UpdateMySharedQuestionFavoriteStatusResultDTO> updateMySharedQuestionFavoriteStatus(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId, @RequestParam(name = "isFavorite") Boolean isFavorite);
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
@@ -59,15 +59,17 @@ public interface QuestionControllerDocs {
             @RequestParam(name = "cursorId", required = false) Long cursorId,
             @RequestParam(name = "size", required = false) Integer size);
 
-    @Operation(summary = "내가 발행한 공유질문 리스트 조회 (카테고리 필터링 가능)", description = "사용자 본인이 발행한 공유질문 리스트를 조회하는 기능입니다. (카테고리 필터링 가능)")
+    @Operation(summary = "내가 발행한 공유질문 리스트 조회 (카테고리 필터링 ver)", description = "사용자 본인이 발행한 공유질문 리스트를 조회하는 기능입니다. (카테고리 필터링 ver)")
     @Parameters({
             @Parameter(name = "categoryId", description = "카테고리ID입니다. (0 또는 생략 시 전체 조회)"),
+            @Parameter(name = "favorite", description = "즐겨찾기 필터링"),
             @Parameter(name = "cursorId", description = "커서 - 마지막 질문 ID, 첫 요청 때는 null"),
             @Parameter(name = "size", description = "한 페이지당 조회할 질문 수, 기본값 10", required = false),
     })
-    ApiResponse<QuestionResponseDTO.MySharedQuestionListResultDTO> getMySharedQuestionList(
+    ApiResponse<CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO>> getMySharedQuestionList(
             @CurrentMember Member member,
             @RequestParam(name = "categoryId", required = false) Long categoryId,
+            @RequestParam(name = "favorite", required = false) Boolean favorite,
             @RequestParam(name = "cursorId", required = false) Long cursorId,
             @RequestParam(name = "size", required = false) Integer size);
 

--- a/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
@@ -202,4 +202,15 @@ public class QuestionResponseDTO {
         private LocalDateTime createdAt;
     }
 
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class UpdateMySharedQuestionFavoriteStatusResultDTO {
+
+        private Long id;
+
+        private LocalDateTime createdAt;
+    }
+
 }

--- a/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
@@ -51,14 +51,14 @@ public class QuestionResponseDTO {
         private LocalDateTime createdAt;
     }
 
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class MySharedQuestionListResultDTO {
-        private Long mySharedQuestionCnt;
-        private CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO> mySharedQuestionList;
-    }
+//    @Builder
+//    @Getter
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class MySharedQuestionListResultDTO {
+//        private Long mySharedQuestionCnt;
+//        private CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO> mySharedQuestionList;
+//    }
 
     @Getter
     @AllArgsConstructor
@@ -73,6 +73,8 @@ public class QuestionResponseDTO {
         private String question;
 
         private Long sharedCount;
+
+        private Boolean isFavorite;
 
         private LocalDateTime createdAt;
     }

--- a/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
@@ -51,14 +51,31 @@ public class QuestionResponseDTO {
         private LocalDateTime createdAt;
     }
 
-//    @Builder
-//    @Getter
-//    @NoArgsConstructor
-//    @AllArgsConstructor
-//    public static class MySharedQuestionListResultDTO {
-//        private Long mySharedQuestionCnt;
-//        private CursorDTO<QuestionResponseDTO.MySharedQuestionResultDTO> mySharedQuestionList;
-//    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MySharedQuestionPreviewListResultDTO {
+        private Long mySharedQuestionCnt;
+        private CursorDTO<QuestionResponseDTO.MySharedQuestionPreviewResultDTO> mySharedQuestionList;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class MySharedQuestionPreviewResultDTO {
+
+        private Long id;
+
+        private List<CategoryResponseDTO.CategoryInfoDTO> categories;
+
+        private String question;
+
+        private Long sharedCount;
+
+        private LocalDateTime createdAt;
+    }
 
     @Getter
     @AllArgsConstructor


### PR DESCRIPTION
## 💡 작업 내용 요약
- 내가 발행한 공유질문 즐겨찾기 필터링 추가
- 내가 발행한 공유질문 목록 조회 페이지별로 분리 (개수 포함 ver, 카테고리 필터링 ver)
- 내가 발행한 공유질문 즐겨찾기 추가/삭제

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작을 확인했는가?
- [ ] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #116 

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
