### PR TITLE
Feat: 검색 화면 관련 API 구현

### DIFF
--- a/src/main/java/com/coredisc/application/service/member/MemberQueryService.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberQueryService.java
@@ -24,5 +24,5 @@ public interface MemberQueryService {
     CursorDTO<MemberResponseDTO.MyHomePostDTO> getUserHomePosts(Member member, String targetUsername, Long cursorId, Pageable page);
 
     // 검색 화면 사용자 검색
-    CursorDTO<MemberResponseDTO.SearchMemberResultDTO> getMemberSearchList(Member member, String keyword, Long cursorId, Integer pageSize);
+    CursorDTO<MemberResponseDTO.SearchMemberResultDTO> getMemberSearchList(Member member, String keyword, Boolean record, Long cursorId, Integer pageSize);
 }

--- a/src/main/java/com/coredisc/application/service/member/MemberQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.coredisc.application.service.member;
 
 import com.coredisc.common.apiPayload.status.ErrorStatus;
 import com.coredisc.common.converter.MemberConverter;
+import com.coredisc.common.converter.SearchHistoryConverter;
 import com.coredisc.common.exception.handler.AuthHandler;
 import com.coredisc.common.exception.handler.MemberHandler;
 import com.coredisc.common.exception.handler.MyHomeHandler;
@@ -9,6 +10,7 @@ import com.coredisc.common.util.FormatNumberUtil;
 import com.coredisc.domain.block.BlockRepository;
 import com.coredisc.domain.common.enums.PostStatus;
 import com.coredisc.domain.common.enums.PublicityType;
+import com.coredisc.domain.common.enums.SearchType;
 import com.coredisc.domain.disc.DiscRepository;
 import com.coredisc.domain.follow.FollowRepository;
 import com.coredisc.domain.member.Member;
@@ -19,6 +21,8 @@ import com.coredisc.domain.post.PostAnswerImage;
 import com.coredisc.domain.post.PostRepository;
 import com.coredisc.domain.profileImg.ProfileImg;
 import com.coredisc.domain.profileImg.ProfileImgRepository;
+import com.coredisc.domain.searchHistory.SearchHistory;
+import com.coredisc.domain.searchHistory.SearchHistoryRepository;
 import com.coredisc.presentation.dto.cursor.CursorDTO;
 import com.coredisc.presentation.dto.member.MemberResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +43,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     private final PostRepository postRepository;
     private final BlockRepository blockRepository;
     private final DiscRepository discRepository;
+    private final SearchHistoryRepository searchHistoryRepository;
 
 
     @Override
@@ -218,11 +223,24 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
     // 검색 화면 사용자 검색
     @Override
-    public CursorDTO<MemberResponseDTO.SearchMemberResultDTO> getMemberSearchList(Member member, String keyword, Long cursorId, Integer pageSize) {
+    public CursorDTO<MemberResponseDTO.SearchMemberResultDTO> getMemberSearchList(Member member, String keyword, Boolean record, Long cursorId, Integer pageSize) {
         
         // 키워드 없을 시 예외처리
         if (keyword == null || keyword.trim().isEmpty()) {
             throw new MemberHandler(ErrorStatus.INVALID_SEARCH_KEYWORD);
+        }
+
+        // 검색 기록 저장
+        if (Boolean.TRUE.equals(record)) {
+            SearchHistory history = searchHistoryRepository
+                    .findByMemberAndKeywordAndSearchType(member, keyword, SearchType.MEMBER)
+                    .map(existing -> {      // 이미 검색 되어있을 시 최근 검색으로
+                        existing.updateTimestamp();
+                        return existing;
+                    })
+                    .orElseGet(() -> SearchHistoryConverter.toSearchHistory(member, keyword, SearchType.MEMBER));
+
+            searchHistoryRepository.save(history);
         }
 
         List<Member> memberList = memberRepository.findMemberListByKeyword(keyword, cursorId, pageSize);

--- a/src/main/java/com/coredisc/application/service/searchHistory/SearchHistoryCommandService.java
+++ b/src/main/java/com/coredisc/application/service/searchHistory/SearchHistoryCommandService.java
@@ -1,0 +1,10 @@
+package com.coredisc.application.service.searchHistory;
+
+import com.coredisc.domain.member.Member;
+
+public interface SearchHistoryCommandService {
+
+    // 검색 화면 검색 기록 삭제
+    void deleteSearchHistory(Member member, Long historyId);
+
+}

--- a/src/main/java/com/coredisc/application/service/searchHistory/SearchHistoryCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/searchHistory/SearchHistoryCommandServiceImpl.java
@@ -1,0 +1,27 @@
+package com.coredisc.application.service.searchHistory;
+
+import com.coredisc.common.apiPayload.status.ErrorStatus;
+import com.coredisc.common.exception.handler.SearchHistoryHandler;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.searchHistory.SearchHistory;
+import com.coredisc.domain.searchHistory.SearchHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SearchHistoryCommandServiceImpl implements SearchHistoryCommandService {
+
+
+    private final SearchHistoryRepository searchHistoryRepository;
+
+    // 검색 화면 검색 기록 삭제
+    @Override
+    public void deleteSearchHistory(Member member, Long historyId) {
+
+        SearchHistory searchHistory = searchHistoryRepository.findByMemberAndId(member, historyId)
+                .orElseThrow(() -> new SearchHistoryHandler(ErrorStatus.SEARCH_HISTORY_NOT_FOUND));
+
+        searchHistoryRepository.delete(searchHistory);
+    }
+}

--- a/src/main/java/com/coredisc/application/service/searchHistory/SearchHistoryQueryService.java
+++ b/src/main/java/com/coredisc/application/service/searchHistory/SearchHistoryQueryService.java
@@ -1,0 +1,12 @@
+package com.coredisc.application.service.searchHistory;
+
+import com.coredisc.domain.member.Member;
+import com.coredisc.presentation.dto.cursor.CursorDTO;
+import com.coredisc.presentation.dto.searchHistory.SearchHistoryResponseDTO;
+
+import java.time.LocalDateTime;
+
+public interface SearchHistoryQueryService {
+
+    CursorDTO<SearchHistoryResponseDTO.MySearchHistoryResultDTO> getMemberSearchHistoryList(Member member, LocalDateTime cursorSearchedAt, int pageSize);
+}

--- a/src/main/java/com/coredisc/application/service/searchHistory/SearchHistoryQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/searchHistory/SearchHistoryQueryServiceImpl.java
@@ -1,0 +1,40 @@
+package com.coredisc.application.service.searchHistory;
+
+import com.coredisc.common.converter.SearchHistoryConverter;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.searchHistory.SearchHistory;
+import com.coredisc.domain.searchHistory.SearchHistoryRepository;
+import com.coredisc.presentation.dto.cursor.CursorDTO;
+import com.coredisc.presentation.dto.searchHistory.SearchHistoryResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SearchHistoryQueryServiceImpl implements SearchHistoryQueryService {
+
+    private final SearchHistoryRepository searchHistoryRepository;
+
+    @Override
+    public CursorDTO<SearchHistoryResponseDTO.MySearchHistoryResultDTO> getMemberSearchHistoryList(Member member, LocalDateTime cursorSearchedAt, int pageSize) {
+
+
+        List<SearchHistory> searchHistoryList = searchHistoryRepository.findAllByMember(member, cursorSearchedAt, pageSize);
+
+        boolean hasNext = searchHistoryList.size() > pageSize;
+
+        if (hasNext) {
+            searchHistoryList = searchHistoryList.subList(0, pageSize);
+        }
+
+        List<SearchHistoryResponseDTO.MySearchHistoryResultDTO> mySearchHistoryList = searchHistoryList.stream()
+                .map(SearchHistoryConverter::toMySearchHistoryResultDTO)
+                .toList();
+
+        return new CursorDTO<>(mySearchHistoryList, hasNext);
+    }
+
+}

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -129,6 +129,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 검색 관련 에러
     INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "SEARCH4001", "검색어는 비어 있을 수 없습니다."),
+    SEARCH_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "SEARCH4002", "해당되는 사용자의 검색 기록이 없습니다."),
 
     // 페이지 관련 에러
     PAGE_OUT_OF_BOUNDS(HttpStatus.NOT_FOUND, "PAGE4001", "존재하지 않는 페이지입니다."),

--- a/src/main/java/com/coredisc/common/converter/SearchHistoryConverter.java
+++ b/src/main/java/com/coredisc/common/converter/SearchHistoryConverter.java
@@ -1,0 +1,19 @@
+package com.coredisc.common.converter;
+
+import com.coredisc.domain.common.enums.SearchType;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.searchHistory.SearchHistory;
+
+import java.time.LocalDateTime;
+
+public class SearchHistoryConverter {
+
+    public static SearchHistory toSearchHistory(Member member, String keyword, SearchType searchType) {
+        return SearchHistory.builder()
+                .member(member)
+                .keyword(keyword)
+                .searchedAt(LocalDateTime.now())
+                .searchType(searchType)
+                .build();
+    }
+}

--- a/src/main/java/com/coredisc/common/converter/SearchHistoryConverter.java
+++ b/src/main/java/com/coredisc/common/converter/SearchHistoryConverter.java
@@ -3,6 +3,7 @@ package com.coredisc.common.converter;
 import com.coredisc.domain.common.enums.SearchType;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.searchHistory.SearchHistory;
+import com.coredisc.presentation.dto.searchHistory.SearchHistoryResponseDTO;
 
 import java.time.LocalDateTime;
 
@@ -14,6 +15,15 @@ public class SearchHistoryConverter {
                 .keyword(keyword)
                 .searchedAt(LocalDateTime.now())
                 .searchType(searchType)
+                .build();
+    }
+
+    public static SearchHistoryResponseDTO.MySearchHistoryResultDTO toMySearchHistoryResultDTO(SearchHistory searchHistory) {
+
+        return SearchHistoryResponseDTO.MySearchHistoryResultDTO.builder()
+                .id(searchHistory.getId())
+                .keyword(searchHistory.getKeyword())
+                .searchedAt(searchHistory.getSearchedAt())
                 .build();
     }
 }

--- a/src/main/java/com/coredisc/common/exception/handler/SearchHistoryHandler.java
+++ b/src/main/java/com/coredisc/common/exception/handler/SearchHistoryHandler.java
@@ -1,0 +1,10 @@
+package com.coredisc.common.exception.handler;
+
+import com.coredisc.common.apiPayload.code.BaseErrorCode;
+import com.coredisc.common.exception.GeneralException;
+
+public class SearchHistoryHandler extends GeneralException {
+    public SearchHistoryHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/coredisc/domain/common/enums/SearchType.java
+++ b/src/main/java/com/coredisc/domain/common/enums/SearchType.java
@@ -1,0 +1,5 @@
+package com.coredisc.domain.common.enums;
+
+public enum SearchType {
+    MEMBER
+}

--- a/src/main/java/com/coredisc/domain/member/Member.java
+++ b/src/main/java/com/coredisc/domain/member/Member.java
@@ -11,6 +11,7 @@ import com.coredisc.domain.mapping.MemberTerms;
 import com.coredisc.domain.post.Post;
 import com.coredisc.domain.post.PostLike;
 import com.coredisc.domain.profileImg.ProfileImg;
+import com.coredisc.domain.searchHistory.SearchHistory;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
@@ -100,6 +101,9 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "blocked", cascade = CascadeType.ALL)
     private List<Block> blockerList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<SearchHistory> searchHistoryList = new ArrayList<>();
 
     // 메서드
     public void encodePassword(String password) {

--- a/src/main/java/com/coredisc/domain/searchHistory/SearchHistory.java
+++ b/src/main/java/com/coredisc/domain/searchHistory/SearchHistory.java
@@ -1,0 +1,29 @@
+package com.coredisc.domain.searchHistory;
+
+import com.coredisc.domain.common.BaseEntity;
+import com.coredisc.domain.common.enums.SearchType;
+import com.coredisc.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class SearchHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String keyword;
+
+    @Enumerated(EnumType.STRING)
+    private SearchType searchType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/coredisc/domain/searchHistory/SearchHistory.java
+++ b/src/main/java/com/coredisc/domain/searchHistory/SearchHistory.java
@@ -6,6 +6,8 @@ import com.coredisc.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,7 +25,15 @@ public class SearchHistory extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SearchType searchType;
 
+    @Column(nullable = false)
+    private LocalDateTime searchedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    public void updateTimestamp() {
+        this.searchedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/coredisc/domain/searchHistory/SearchHistoryRepository.java
+++ b/src/main/java/com/coredisc/domain/searchHistory/SearchHistoryRepository.java
@@ -15,4 +15,7 @@ public interface SearchHistoryRepository {
 
     List<SearchHistory> findAllByMember(Member member, LocalDateTime cursorSearchedAt, int pageSize);
 
+    Optional<SearchHistory> findByMemberAndId(Member member, Long id);
+
+    void delete(SearchHistory searchHistory);
 }

--- a/src/main/java/com/coredisc/domain/searchHistory/SearchHistoryRepository.java
+++ b/src/main/java/com/coredisc/domain/searchHistory/SearchHistoryRepository.java
@@ -3,6 +3,8 @@ package com.coredisc.domain.searchHistory;
 import com.coredisc.domain.common.enums.SearchType;
 import com.coredisc.domain.member.Member;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface SearchHistoryRepository {
@@ -10,4 +12,7 @@ public interface SearchHistoryRepository {
     Optional<SearchHistory> findByMemberAndKeywordAndSearchType(Member member, String keyword, SearchType searchType);
 
     SearchHistory save(SearchHistory searchHistory);
+
+    List<SearchHistory> findAllByMember(Member member, LocalDateTime cursorSearchedAt, int pageSize);
+
 }

--- a/src/main/java/com/coredisc/domain/searchHistory/SearchHistoryRepository.java
+++ b/src/main/java/com/coredisc/domain/searchHistory/SearchHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.coredisc.domain.searchHistory;
+
+import com.coredisc.domain.common.enums.SearchType;
+import com.coredisc.domain.member.Member;
+
+import java.util.Optional;
+
+public interface SearchHistoryRepository {
+
+    Optional<SearchHistory> findByMemberAndKeywordAndSearchType(Member member, String keyword, SearchType searchType);
+
+    SearchHistory save(SearchHistory searchHistory);
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/searchHistory/JpaSearchHistoryRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/searchHistory/JpaSearchHistoryRepository.java
@@ -11,4 +11,6 @@ public interface JpaSearchHistoryRepository extends JpaRepository<SearchHistory,
 
     Optional<SearchHistory> findByMemberAndKeywordAndSearchType(Member member, String keyword, SearchType searchType);
 
+    Optional<SearchHistory> findByMemberAndId(Member member, Long id);
+
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/searchHistory/JpaSearchHistoryRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/searchHistory/JpaSearchHistoryRepository.java
@@ -1,0 +1,14 @@
+package com.coredisc.infrastructure.repository.searchHistory;
+
+import com.coredisc.domain.common.enums.SearchType;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.searchHistory.SearchHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JpaSearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+
+    Optional<SearchHistory> findByMemberAndKeywordAndSearchType(Member member, String keyword, SearchType searchType);
+
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/searchHistory/SearchHistoryRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/searchHistory/SearchHistoryRepositoryAdapter.java
@@ -4,9 +4,12 @@ import com.coredisc.domain.common.enums.SearchType;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.searchHistory.SearchHistory;
 import com.coredisc.domain.searchHistory.SearchHistoryRepository;
+import com.coredisc.infrastructure.repository.searchHistory.querydsl.QuerySearchHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,6 +17,7 @@ import java.util.Optional;
 public class SearchHistoryRepositoryAdapter implements SearchHistoryRepository {
 
     private final JpaSearchHistoryRepository jpaSearchHistoryRepository;
+    private final QuerySearchHistoryRepository querySearchHistoryRepository;
 
     @Override
     public Optional<SearchHistory> findByMemberAndKeywordAndSearchType(Member member, String keyword, SearchType searchType) {
@@ -23,6 +27,11 @@ public class SearchHistoryRepositoryAdapter implements SearchHistoryRepository {
     @Override
     public SearchHistory save(SearchHistory searchHistory) {
         return jpaSearchHistoryRepository.save(searchHistory);
+    }
+
+    @Override
+    public List<SearchHistory> findAllByMember(Member member, LocalDateTime cursorSearchedAt, int pageSize) {
+        return querySearchHistoryRepository.findAllByMember(member, cursorSearchedAt, pageSize);
     }
 
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/searchHistory/SearchHistoryRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/searchHistory/SearchHistoryRepositoryAdapter.java
@@ -34,4 +34,14 @@ public class SearchHistoryRepositoryAdapter implements SearchHistoryRepository {
         return querySearchHistoryRepository.findAllByMember(member, cursorSearchedAt, pageSize);
     }
 
+    @Override
+    public Optional<SearchHistory> findByMemberAndId(Member member, Long id) {
+        return jpaSearchHistoryRepository.findByMemberAndId(member, id);
+    }
+
+    @Override
+    public void delete(SearchHistory searchHistory) {
+        jpaSearchHistoryRepository.delete(searchHistory);
+    }
+
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/searchHistory/SearchHistoryRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/searchHistory/SearchHistoryRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.coredisc.infrastructure.repository.searchHistory;
+
+import com.coredisc.domain.common.enums.SearchType;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.searchHistory.SearchHistory;
+import com.coredisc.domain.searchHistory.SearchHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class SearchHistoryRepositoryAdapter implements SearchHistoryRepository {
+
+    private final JpaSearchHistoryRepository jpaSearchHistoryRepository;
+
+    @Override
+    public Optional<SearchHistory> findByMemberAndKeywordAndSearchType(Member member, String keyword, SearchType searchType) {
+        return jpaSearchHistoryRepository.findByMemberAndKeywordAndSearchType(member, keyword, searchType);
+    }
+
+    @Override
+    public SearchHistory save(SearchHistory searchHistory) {
+        return jpaSearchHistoryRepository.save(searchHistory);
+    }
+
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/searchHistory/querydsl/QuerySearchHistoryRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/searchHistory/querydsl/QuerySearchHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.coredisc.infrastructure.repository.searchHistory.querydsl;
+
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.searchHistory.SearchHistory;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface QuerySearchHistoryRepository {
+
+    List<SearchHistory> findAllByMember(Member member, LocalDateTime cursorSearchedAt, int pageSize);
+}

--- a/src/main/java/com/coredisc/infrastructure/repository/searchHistory/querydsl/QuerySearchHistoryRepositoryImpl.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/searchHistory/querydsl/QuerySearchHistoryRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.coredisc.infrastructure.repository.searchHistory.querydsl;
+
+import com.coredisc.domain.common.enums.SearchType;
+import com.coredisc.domain.member.Member;
+import com.coredisc.domain.searchHistory.QSearchHistory;
+import com.coredisc.domain.searchHistory.SearchHistory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class QuerySearchHistoryRepositoryImpl implements QuerySearchHistoryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QSearchHistory qSearchHistory = QSearchHistory.searchHistory;
+
+    @Override
+    public List<SearchHistory> findAllByMember(Member member, LocalDateTime cursorSearchedAt, int pageSize) {
+
+        return jpaQueryFactory
+                .selectFrom(qSearchHistory)
+                .where(
+                        qSearchHistory.member.eq(member),
+                        qSearchHistory.searchType.eq(SearchType.MEMBER),
+                        cursorSearchedAt != null ? qSearchHistory.searchedAt.lt(cursorSearchedAt) : null
+                )
+                .orderBy(qSearchHistory.searchedAt.desc())
+                .limit(pageSize + 1)
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/coredisc/presentation/controller/SearchController.java
+++ b/src/main/java/com/coredisc/presentation/controller/SearchController.java
@@ -1,6 +1,7 @@
 package com.coredisc.presentation.controller;
 
 import com.coredisc.application.service.member.MemberQueryService;
+import com.coredisc.application.service.searchHistory.SearchHistoryCommandService;
 import com.coredisc.application.service.searchHistory.SearchHistoryQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.domain.member.Member;
@@ -10,10 +11,7 @@ import com.coredisc.presentation.dto.member.MemberResponseDTO;
 import com.coredisc.presentation.dto.searchHistory.SearchHistoryResponseDTO;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
@@ -24,6 +22,7 @@ public class SearchController implements SearchControllerDocs {
 
     private final MemberQueryService memberQueryService;
     private final SearchHistoryQueryService searchHistoryQueryService;
+    private final SearchHistoryCommandService searchHistoryCommandService;
 
     private static final int DEFAULT_PAGE_SIZE = 10; // 한페이지당 개수
 
@@ -53,5 +52,13 @@ public class SearchController implements SearchControllerDocs {
             size = DEFAULT_PAGE_SIZE;
 
         return ApiResponse.onSuccess(searchHistoryQueryService.getMemberSearchHistoryList(member, cursorSearchedAt, size));
+    }
+
+    @DeleteMapping("/member/history/{historyId}")
+    public ApiResponse<String> deleteSearchHistory(@CurrentMember Member member, @PathVariable(name = "historyId") Long historyId) {
+
+        searchHistoryCommandService.deleteSearchHistory(member, historyId);
+
+        return ApiResponse.onSuccess("검색 기록이 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/SearchController.java
+++ b/src/main/java/com/coredisc/presentation/controller/SearchController.java
@@ -26,13 +26,14 @@ public class SearchController implements SearchControllerDocs {
     public ApiResponse<CursorDTO<MemberResponseDTO.SearchMemberResultDTO>> getMemberSearchList(
             @CurrentMember Member member,
             @RequestParam(name = "keyword") String keyword,
+            @RequestParam(name = "record") Boolean record,
             @RequestParam(name = "cursorId", required = false) Long cursorId,
             @RequestParam(name = "size", required = false) Integer size) {
 
         if (size == null)
             size = DEFAULT_PAGE_SIZE;
 
-        return ApiResponse.onSuccess(memberQueryService.getMemberSearchList(member, keyword, cursorId, size));
+        return ApiResponse.onSuccess(memberQueryService.getMemberSearchList(member, keyword, record, cursorId, size));
 
     }
 }

--- a/src/main/java/com/coredisc/presentation/controller/SearchController.java
+++ b/src/main/java/com/coredisc/presentation/controller/SearchController.java
@@ -1,11 +1,13 @@
 package com.coredisc.presentation.controller;
 
 import com.coredisc.application.service.member.MemberQueryService;
+import com.coredisc.application.service.searchHistory.SearchHistoryQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.controllerdocs.SearchControllerDocs;
 import com.coredisc.presentation.dto.cursor.CursorDTO;
 import com.coredisc.presentation.dto.member.MemberResponseDTO;
+import com.coredisc.presentation.dto.searchHistory.SearchHistoryResponseDTO;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,12 +15,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequestMapping("/api/search")
 @RequiredArgsConstructor
 public class SearchController implements SearchControllerDocs {
 
     private final MemberQueryService memberQueryService;
+    private final SearchHistoryQueryService searchHistoryQueryService;
+
     private static final int DEFAULT_PAGE_SIZE = 10; // 한페이지당 개수
 
 
@@ -35,5 +41,17 @@ public class SearchController implements SearchControllerDocs {
 
         return ApiResponse.onSuccess(memberQueryService.getMemberSearchList(member, keyword, record, cursorId, size));
 
+    }
+
+    @GetMapping("/members/history")
+    public ApiResponse<CursorDTO<SearchHistoryResponseDTO.MySearchHistoryResultDTO>> getMemberSearchHistoryList(
+            @CurrentMember Member member,
+            @RequestParam(name = "cursorSearchedAt", required = false) LocalDateTime cursorSearchedAt,
+            @RequestParam(name = "size", required = false) Integer size) {
+
+        if (size == null)
+            size = DEFAULT_PAGE_SIZE;
+
+        return ApiResponse.onSuccess(searchHistoryQueryService.getMemberSearchHistoryList(member, cursorSearchedAt, size));
     }
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/SearchControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/SearchControllerDocs.java
@@ -18,12 +18,14 @@ public interface SearchControllerDocs {
     @Operation(summary = "검색 화면 검색한 사용자 목록 조회", description = "검색한 사용자 목록을 조회하는 기능입니다.")
     @Parameters({
             @Parameter(name = "keyword", description = "검색어"),
+            @Parameter(name = "record", description = "최근 검색 기록에 저장할지 여부"),
             @Parameter(name = "cursorId", description = "커서 - 마지막 사용자 ID, 첫 요청 때는 null"),
             @Parameter(name = "size", description = "한 페이지당 조회할 질문 수, 기본값 10"),
     })
     ApiResponse<CursorDTO<MemberResponseDTO.SearchMemberResultDTO>> getMemberSearchList(
             @CurrentMember Member member,
             @RequestParam(name = "keyword") String keyword,
+            @RequestParam(name = "record", required = false) Boolean record,
             @RequestParam(name = "cursorId", required = false) Long cursorId,
             @RequestParam(name = "size", required = false) Integer size);
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/SearchControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/SearchControllerDocs.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDateTime;
@@ -41,4 +42,10 @@ public interface SearchControllerDocs {
             @CurrentMember Member member,
             @RequestParam(name = "cursorSearchedAt", required = false) LocalDateTime cursorSearchedAt,
             @RequestParam(name = "size", required = false) Integer size);
+
+    @Operation(summary = "검색 화면 검색 기록 삭제", description = "사용자의최근 검색 기록을 삭제하는 기능입니다.")
+    @Parameters({
+            @Parameter(name = "historyId", description = "검색 내역ID pathVariable입니다."),
+    })
+    ApiResponse<String> deleteSearchHistory(@CurrentMember Member member, @PathVariable(name = "historyId") Long historyId);
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/SearchControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/SearchControllerDocs.java
@@ -5,12 +5,15 @@ import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.cursor.CursorDTO;
 import com.coredisc.presentation.dto.member.MemberResponseDTO;
+import com.coredisc.presentation.dto.searchHistory.SearchHistoryResponseDTO;
 import com.coredisc.security.jwt.annotaion.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDateTime;
 
 @Tag(name = "Search", description = "검색 관련 API")
 public interface SearchControllerDocs {
@@ -27,5 +30,15 @@ public interface SearchControllerDocs {
             @RequestParam(name = "keyword") String keyword,
             @RequestParam(name = "record", required = false) Boolean record,
             @RequestParam(name = "cursorId", required = false) Long cursorId,
+            @RequestParam(name = "size", required = false) Integer size);
+
+    @Operation(summary = "검색 화면 최근 사용자 검색 기록 조회", description = "최근에 검색했던 사용자 목록을 조회하는 기능입니다.")
+    @Parameters({
+            @Parameter(name = "cursorSearchedAt", description = "커서 - 마지막 searchedAt, 첫 요청 때는 null"),
+            @Parameter(name = "size", description = "한 페이지당 조회할 질문 수, 기본값 10"),
+    })
+    ApiResponse<CursorDTO<SearchHistoryResponseDTO.MySearchHistoryResultDTO>> getMemberSearchHistoryList(
+            @CurrentMember Member member,
+            @RequestParam(name = "cursorSearchedAt", required = false) LocalDateTime cursorSearchedAt,
             @RequestParam(name = "size", required = false) Integer size);
 }

--- a/src/main/java/com/coredisc/presentation/dto/searchHistory/SearchHistoryResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/searchHistory/SearchHistoryResponseDTO.java
@@ -1,0 +1,24 @@
+package com.coredisc.presentation.dto.searchHistory;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class SearchHistoryResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MySearchHistoryResultDTO {
+
+        private Long id;
+
+        private String keyword;
+
+        private LocalDateTime searchedAt;
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용 요약
어떤 기능/버그/리팩토링을 했는지 요약해주세요.

- 사용자 검색 기록을 위한 테이블 생성
- 검색 조회 API 수정
- 최근 검색 기록 조회 API
- 최근 검색 기록 삭제 API


<img width="266" height="118" alt="image" src="https://github.com/user-attachments/assets/a235ac39-f14c-4132-9407-ae489087c027" />


## ✅ 체크리스트
- [ ] 로컬에서 정상 동작을 확인했는가?
- [ ] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #

## 📎 기타 참고사항
검색 종류가 확장될 수도 있다고 가정하고 searchType을 추가했는데 별로면 알려주세요. 
사용자 검색 시 record=true/false에 따라 검색 기록을 저장할 수 있도록 했습니다. 
