### PR TITLE
Refactor: 팔로워,팔로잉,차단 유저 목록 조회 시 프로필 이미지도 반환하도록 수정

### DIFF
--- a/src/main/java/com/coredisc/application/service/block/BlockQueryService.java
+++ b/src/main/java/com/coredisc/application/service/block/BlockQueryService.java
@@ -1,12 +1,9 @@
 package com.coredisc.application.service.block;
 
-import com.coredisc.domain.block.Block;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.block.BlockResponseDTO;
 import com.coredisc.presentation.dto.cursor.CursorDTO;
 import org.springframework.data.domain.Pageable;
-
-import java.util.List;
 
 public interface BlockQueryService {
 

--- a/src/main/java/com/coredisc/application/service/block/BlockQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/block/BlockQueryServiceImpl.java
@@ -2,7 +2,6 @@ package com.coredisc.application.service.block;
 
 import com.coredisc.common.converter.BlockConverter;
 import com.coredisc.domain.block.Block;
-import com.coredisc.domain.block.BlockRepository;
 import com.coredisc.domain.member.Member;
 import com.coredisc.infrastructure.repository.block.queryDsl.QueryBlockRepository;
 import com.coredisc.presentation.dto.block.BlockResponseDTO;

--- a/src/main/java/com/coredisc/common/converter/BlockConverter.java
+++ b/src/main/java/com/coredisc/common/converter/BlockConverter.java
@@ -4,9 +4,6 @@ import com.coredisc.domain.block.Block;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.block.BlockResponseDTO;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 public class BlockConverter {
 
     public static Block toBlock(Member member, Member blockedMember) {

--- a/src/main/java/com/coredisc/common/converter/BlockConverter.java
+++ b/src/main/java/com/coredisc/common/converter/BlockConverter.java
@@ -21,6 +21,7 @@ public class BlockConverter {
                 .id(block.getId())
                 .blockerId(block.getBlocker().getId())
                 .blockedId(block.getBlocked().getId())
+                .profileImgDTO(ProfileImgConverter.toProfileImgDTO(block.getBlocked().getProfileImg()))
                 .createdAt(block.getCreatedAt())
                 .build();
     }
@@ -30,6 +31,7 @@ public class BlockConverter {
                 .blockedId(block.getBlocked().getId())
                 .blockedNickname(block.getBlocked().getNickname())
                 .blockedUsername(block.getBlocked().getUsername())
+                .profileImgDTO(ProfileImgConverter.toProfileImgDTO(block.getBlocked().getProfileImg()))
                 .build();
     }
 

--- a/src/main/java/com/coredisc/common/converter/FollowConverter.java
+++ b/src/main/java/com/coredisc/common/converter/FollowConverter.java
@@ -24,7 +24,7 @@ public class FollowConverter {
                 .followerId(follow.getFollower().getId())
                 .nickname(follow.getFollower().getNickname())
                 .username(follow.getFollower().getUsername())
-                //.profileImgDTO(ProfileImgConverter.toProfileImgDTO(follow.getFollower().getProfileImg()))
+                .profileImgDTO(ProfileImgConverter.toProfileImgDTO(follow.getFollower().getProfileImg()))
                 .isCircle(follow.isCircle())
                 .isMutual(isMutual)
                 .build();
@@ -51,7 +51,7 @@ public class FollowConverter {
                 .followingId(follow.getFollowing().getId())
                 .nickname(follow.getFollowing().getNickname())
                 .username(follow.getFollowing().getUsername())
-                //.profileImgDTO(ProfileImgConverter.toProfileImgDTO(follow.getFollower().getProfileImg()))
+                .profileImgDTO(ProfileImgConverter.toProfileImgDTO(follow.getFollower().getProfileImg()))
                 .build();
     }
 

--- a/src/main/java/com/coredisc/presentation/dto/block/BlockResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/block/BlockResponseDTO.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public class BlockResponseDTO {
     @Getter

--- a/src/main/java/com/coredisc/presentation/dto/block/BlockResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/block/BlockResponseDTO.java
@@ -1,5 +1,6 @@
 package com.coredisc.presentation.dto.block;
 
+import com.coredisc.presentation.dto.profileImg.ProfileImgResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,7 @@ public class BlockResponseDTO {
         private Long id;
         private Long blockerId;
         private Long blockedId;
+        private ProfileImgResponseDTO.ProfileImgDTO profileImgDTO;
         private LocalDateTime createdAt;
     }
 
@@ -28,7 +30,7 @@ public class BlockResponseDTO {
         private Long blockedId;
         private String blockedNickname;
         private String blockedUsername;
-        private String blockedImageUrl;
+        private ProfileImgResponseDTO.ProfileImgDTO profileImgDTO;
     }
 
 }


### PR DESCRIPTION
## 💡 작업 내용 요약
어떤 기능/버그/리팩토링을 했는지 요약해주세요.

팔로워,팔로잉,차단 유저 목록 조회 시 프로필 이미지도 반환하도록 수정

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #124 

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
