### PR TITLE
Feat: 임시저장 게시글 삭제 배치 처리

### DIFF
--- a/src/main/java/com/coredisc/application/schedule/BatchScheduler.java
+++ b/src/main/java/com/coredisc/application/schedule/BatchScheduler.java
@@ -1,6 +1,7 @@
-package com.coredisc.infrastructure.schedule;
+package com.coredisc.application.schedule;
 
 import com.coredisc.application.service.disc.DiscBatchService;
+import com.coredisc.application.service.post.PostCommandService;
 import com.coredisc.application.service.reportStat.ReportStatBatchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ public class BatchScheduler {
 
     private final DiscBatchService discBatchService;
     private final ReportStatBatchService reportStatBatchService;
+    private final PostCommandService postCommandService;
 
     // 매일 자정 (00:00:00)
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
@@ -24,6 +26,7 @@ public class BatchScheduler {
         log.info("🔄 [배치] {}일자 통계 데이터 생성 시작", targetDate);
         runDailyBatch(targetDate);
         log.info("✅ [배치] {}일자 통계 데이터 생성 완료", targetDate);
+        postCommandService.cleanupOldTempPosts(targetDate);
     }
 
     // 매월 1일 00:00:00

--- a/src/main/java/com/coredisc/application/service/post/PostCommandService.java
+++ b/src/main/java/com/coredisc/application/service/post/PostCommandService.java
@@ -6,6 +6,9 @@ import com.coredisc.presentation.dto.post.PostRequestDTO;
 import com.coredisc.presentation.dto.post.PostResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+import java.util.Date;
+
 public interface PostCommandService {
 
     public PostResponseDTO.CreatePostResultDto createEmptyPost(Member member, PostRequestDTO.CreatePostDto req);
@@ -18,4 +21,5 @@ public interface PostCommandService {
 
     void deletePost(Member member, Long postId);
 
+    void cleanupOldTempPosts(LocalDate cutoffDate);
 }

--- a/src/main/java/com/coredisc/application/service/post/PostCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/post/PostCommandServiceImpl.java
@@ -407,10 +407,35 @@ public class PostCommandServiceImpl implements PostCommandService {
      * 임시저장 게시글 정리 (배치 작업용)
      */
     @Transactional
-    public void cleanupOldTempPosts(int daysOld) {
-        // 일정 기간 이상 된 임시저장 게시글들을 정리
-        // 실제 구현에서는 JpaRepository의 deleteOldTempPosts 메서드 활용
-        log.info("{}일 이전 임시저장 게시글 정리 작업 시작", daysOld);
+    public void cleanupOldTempPosts(LocalDate cutoffDate) {
+        log.info("[배치] {}일 이전 임시저장 게시글 정리 작업 시작", cutoffDate);
+
+
+        List<Post> postToDelete = postRepository.findAllByStatusAndCreatedAtBefore(PostStatus.TEMP, cutoffDate.plusDays(1).atStartOfDay());
+
+        int deletedCount =0;
+
+
+        for(Post post : postToDelete) {
+            try {
+                List<String> imageUrls =extractImageUrls(post);
+                List<String> thumbnailUrls = extractThumbnailUrls(post);
+
+                amazonS3Manager.deleteImagesByUrls(imageUrls);
+                amazonS3Manager.deleteImagesByUrls(thumbnailUrls);
+
+                postRepository.delete(post);
+                deletedCount++;
+
+            }
+            catch (Exception e) {
+                log.error("TEMP 게시글 삭제 실패 - ID: {}, 에러: {}", post.getId(), e.getMessage(), e);
+                throw new PostHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+            }
+        }
+
+
+        log.info("[배치] 임시저장 게시글 삭제 완료 - 총 {}건", deletedCount);
     }
 
 }

--- a/src/main/java/com/coredisc/domain/post/PostRepository.java
+++ b/src/main/java/com/coredisc/domain/post/PostRepository.java
@@ -49,4 +49,6 @@ public interface PostRepository {
     // 특정 회원이 특정 날짜에 발행한 게시글이 있는가?
     boolean existsByMemberAndStatusAndCreatedAtBetween(Member member, PostStatus status, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
+    List<Post> findAllByStatusAndCreatedAtBefore(PostStatus status, LocalDateTime createdAt);
+
     }

--- a/src/main/java/com/coredisc/infrastructure/repository/post/JpaPostRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/post/JpaPostRepository.java
@@ -6,6 +6,9 @@ import com.coredisc.domain.member.Member;
 import com.coredisc.domain.common.enums.PublicityType;
 import com.coredisc.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -19,6 +22,8 @@ public interface JpaPostRepository extends JpaRepository<Post, Long> {
     long countByMemberAndStatusAndPublicityIn(Member member, PostStatus status, List<PublicityType> publicityTypes);
 
     List<Post> findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(Member member, LocalDateTime start, LocalDateTime end);
+
+    List<Post> findAllByStatusAndCreatedAtBefore(PostStatus status, LocalDateTime startOfDay);
 }
 
 

--- a/src/main/java/com/coredisc/infrastructure/repository/post/PostRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/post/PostRepositoryAdaptor.java
@@ -110,6 +110,11 @@ public class PostRepositoryAdaptor implements PostRepository {
     }
 
     @Override
+    public List<Post> findAllByStatusAndCreatedAtBefore(PostStatus status, LocalDateTime createdAt) {
+        return jpaPostRepository.findAllByStatusAndCreatedAtBefore(status, createdAt);
+    }
+
+    @Override
     public List<Post> findPostsByCreatedDate(LocalDate targetDate) {
         return queryPostRepository.findPostsByCreatedDate(targetDate);
     }

--- a/src/test/java/com/coredisc/BatchSchedulerTest.java
+++ b/src/test/java/com/coredisc/BatchSchedulerTest.java
@@ -1,6 +1,6 @@
 package com.coredisc;
 
-import com.coredisc.infrastructure.schedule.BatchScheduler;
+import com.coredisc.application.schedule.BatchScheduler;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## 💡 작업 내용 요약
임시저장 게시글 삭제 및 관련 S3 이미지 정리 로직을 배치 처리로 구현했습니다.


## ✅ 체크리스트
- [ ] 로컬에서 정상 동작을 확인했는가?
- [ ] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #129 

## 📎 기타 참고사항


**infrastructure.schedule 패키지에 있던 스케줄러 클래스를 application.schedule로 이동했습니다.**

현재 스케줄러는  `Service`를 직접 참조하고 있으므로(PostCommandService,BatchService 등 ) application layer 내의 scheduler 패키지로 이동시켰습니다.

Layered Architecture 원칙에 따라 상위 계층(application)이 하위 계층(infra)을 참조할 수 있지만, 하위 계층이 상위 계층을 참조하는 것은 DIP 위반이라고 생각합니다.

예외적으로 스케줄러가 비즈니스 로직(Service 계층)을 전혀 참조하지 않고 단순한 인프라성 작업 (캐시 삭제, S3 접근 , 로그 정리 등)만 수행하는 경우는 `infrastructure.scheduler` 패키지에 위치시켜도 된다고 생각합니다.

이러한 경우는 의존성 역전 문제가 없고 역할이 명확한 컴포넌트로 보기 때문입니다.

@Jieun13 
해당 구조에 대해 어떻게 생각하시는지 의견 주시면 감사하겠습니다.




