### PR TITLE
Refactor: 기본 질문 목록 선택&즐겨찾기 여부 추가

### DIFF
--- a/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
@@ -130,7 +130,75 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
             Long cursorId,
             int pageSize){
 
-        return customQuestionRepository.findBasicQuestionListByKeyword(member.getId(), categoryId, keyword, cursorCreatedAt, cursorQuestionType, cursorId, pageSize);
+        LocalDate today = LocalDate.now();
+        LocalDate startOfMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate endOfMonth = startOfMonth.plusMonths(1).minusDays(1);
+
+        categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new QuestionHandler(ErrorStatus.CATEGORY_NOT_FOUND));
+
+        CursorDTO<QuestionResponseDTO.BasicQuestionResultDTO> cursorDTO =
+                customQuestionRepository.findBasicQuestionListByKeyword(member.getId(), categoryId, keyword, cursorCreatedAt, cursorQuestionType, cursorId, pageSize);
+
+        List<TodayQuestion> myTodayQuestionList = new ArrayList<>();
+
+        for (int order = 1; order <= 4; order++) {
+            Optional<TodayQuestion> todayQuestion;
+
+            if (order == 4) {
+                todayQuestion = todayQuestionRepository.findByMemberAndQuestionOrderAndSelectedDate(member, order, today);
+            } else {
+                todayQuestion = todayQuestionRepository.findByMemberAndQuestionOrderAndSelectedDateBetween(member, order, startOfMonth, endOfMonth);
+            }
+
+            todayQuestion.ifPresent(myTodayQuestionList::add);
+        }
+
+        List<QuestionResponseDTO.BasicQuestionResultDTO> basicQuestionList = cursorDTO.getValues().stream()
+                .map(basicQuestionResultDTO -> {
+                    // 오늘 질문 여부
+                    boolean isSelected = myTodayQuestionList.stream()
+                            .anyMatch(q ->
+                                    (
+                                            ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType()) || "DEFAULT".equals(basicQuestionResultDTO.getQuestionType()))
+                                                    && q.getOfficialQuestion() != null
+                                                    && q.getOfficialQuestion().getId().equals(basicQuestionResultDTO.getId())
+                                    )
+                                            ||
+                                            (
+                                                    "PERSONAL".equals(basicQuestionResultDTO.getQuestionType())
+                                                            && q.getPersonalQuestion() != null
+                                                            && q.getPersonalQuestion().getId().equals(basicQuestionResultDTO.getId())
+                                            )
+                            );
+
+                    // 즐겨찾기 여부
+                    boolean isFavorite = false;
+                    if ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType()) || "DEFAULT".equals(basicQuestionResultDTO.getQuestionType())) {
+                        Boolean officialFavorite = officialQuestionRepository.findIsFavoriteById(basicQuestionResultDTO.getId());
+                        if (Boolean.TRUE.equals(officialFavorite)) {
+                            isFavorite = true;
+                        } else {
+                            isFavorite = memberOfficialQuestionRepository
+                                    .existsByMemberIdAndOfficialQuestionIdAndIsFavoriteTrue(member.getId(), basicQuestionResultDTO.getId());
+                        }
+                    } else if ("PERSONAL".equals(basicQuestionResultDTO.getQuestionType())) {
+                        isFavorite = false;
+                    }
+
+                    // TODO: converter 분리
+                    return QuestionResponseDTO.BasicQuestionResultDTO.builder()
+                            .id(basicQuestionResultDTO.getId())
+                            .questionType(basicQuestionResultDTO.getQuestionType())
+                            .question(basicQuestionResultDTO.getQuestion())
+                            .isSelected(isSelected)
+                            .isFavorite(isFavorite)
+                            .createdAt(basicQuestionResultDTO.getCreatedAt())
+                            .build();
+                })
+                .toList();
+
+        return new CursorDTO<>(basicQuestionList, cursorDTO.getHasNext());
     }
 
     // 내가 발행한 공유질문 리스트 조회 (개수 포함 ver)

--- a/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
@@ -45,12 +45,78 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
             LocalDateTime cursorCreatedAt,
             String cursorQuestionType,
             Long cursorId,
-            int pageSize){
+            int pageSize) {
+
+        LocalDate today = LocalDate.now();
+        LocalDate startOfMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate endOfMonth = startOfMonth.plusMonths(1).minusDays(1);
 
         categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new QuestionHandler(ErrorStatus.CATEGORY_NOT_FOUND));
 
-        return customQuestionRepository.findBasicQuestionListByCategories(member.getId(), categoryId, cursorCreatedAt, cursorQuestionType, cursorId, pageSize);
+        CursorDTO<QuestionResponseDTO.BasicQuestionResultDTO> cursorDTO =
+                customQuestionRepository.findBasicQuestionListByCategories(
+                        member.getId(), categoryId, cursorCreatedAt, cursorQuestionType, cursorId, pageSize);
+
+        List<TodayQuestion> myTodayQuestionList = new ArrayList<>();
+
+        for (int order = 1; order <= 4; order++) {
+            Optional<TodayQuestion> todayQuestion;
+
+            if (order == 4) {
+                todayQuestion = todayQuestionRepository.findByMemberAndQuestionOrderAndSelectedDate(member, order, today);
+            } else {
+                todayQuestion = todayQuestionRepository.findByMemberAndQuestionOrderAndSelectedDateBetween(member, order, startOfMonth, endOfMonth);
+            }
+
+            todayQuestion.ifPresent(myTodayQuestionList::add);
+        }
+
+        List<QuestionResponseDTO.BasicQuestionResultDTO> basicQuestionList = cursorDTO.getValues().stream()
+                .map(basicQuestionResultDTO -> {
+                    // 오늘 질문 여부
+                    boolean isSelected = myTodayQuestionList.stream()
+                            .anyMatch(q ->
+                                    (
+                                            ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType()) || "DEFAULT".equals(basicQuestionResultDTO.getQuestionType()))
+                                                    && q.getOfficialQuestion() != null
+                                                    && q.getOfficialQuestion().getId().equals(basicQuestionResultDTO.getId())
+                                    )
+                                            ||
+                                            (
+                                                    "PERSONAL".equals(basicQuestionResultDTO.getQuestionType())
+                                                            && q.getPersonalQuestion() != null
+                                                            && q.getPersonalQuestion().getId().equals(basicQuestionResultDTO.getId())
+                                            )
+                            );
+
+                    // 즐겨찾기 여부
+                    boolean isFavorite = false;
+                    if ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType()) || "DEFAULT".equals(basicQuestionResultDTO.getQuestionType())) {
+                        Boolean officialFavorite = officialQuestionRepository.findIsFavoriteById(basicQuestionResultDTO.getId());
+                        if (Boolean.TRUE.equals(officialFavorite)) {
+                            isFavorite = true;
+                        } else {
+                            isFavorite = memberOfficialQuestionRepository
+                                    .existsByMemberIdAndOfficialQuestionIdAndIsFavoriteTrue(member.getId(), basicQuestionResultDTO.getId());
+                        }
+                    } else if ("PERSONAL".equals(basicQuestionResultDTO.getQuestionType())) {
+                        isFavorite = false;
+                    }
+
+                    // TODO: converter 분리
+                    return QuestionResponseDTO.BasicQuestionResultDTO.builder()
+                            .id(basicQuestionResultDTO.getId())
+                            .questionType(basicQuestionResultDTO.getQuestionType())
+                            .question(basicQuestionResultDTO.getQuestion())
+                            .isSelected(isSelected)
+                            .isFavorite(isFavorite)
+                            .createdAt(basicQuestionResultDTO.getCreatedAt())
+                            .build();
+                })
+                .toList();
+
+        return new CursorDTO<>(basicQuestionList, cursorDTO.getHasNext());
     }
 
     // 기본 질문 검색 리스트 조회

--- a/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
@@ -93,7 +93,7 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
                     // 즐겨찾기 여부
                     boolean isFavorite = false;
                     if ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType()) || "DEFAULT".equals(basicQuestionResultDTO.getQuestionType())) {
-                        Boolean officialFavorite = officialQuestionRepository.findIsFavoriteById(basicQuestionResultDTO.getId());
+                        Boolean officialFavorite = officialQuestionRepository.findIsFavoriteByIdAndMember(basicQuestionResultDTO.getId(), member);
                         if (Boolean.TRUE.equals(officialFavorite)) {
                             isFavorite = true;
                         } else {
@@ -175,7 +175,7 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
                     // 즐겨찾기 여부
                     boolean isFavorite = false;
                     if ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType()) || "DEFAULT".equals(basicQuestionResultDTO.getQuestionType())) {
-                        Boolean officialFavorite = officialQuestionRepository.findIsFavoriteById(basicQuestionResultDTO.getId());
+                        Boolean officialFavorite = officialQuestionRepository.findIsFavoriteByIdAndMember(basicQuestionResultDTO.getId(), member);
                         if (Boolean.TRUE.equals(officialFavorite)) {
                             isFavorite = true;
                         } else {

--- a/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
@@ -104,15 +104,7 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
                         isFavorite = false;
                     }
 
-                    // TODO: converter 분리
-                    return QuestionResponseDTO.BasicQuestionResultDTO.builder()
-                            .id(basicQuestionResultDTO.getId())
-                            .questionType(basicQuestionResultDTO.getQuestionType())
-                            .question(basicQuestionResultDTO.getQuestion())
-                            .isSelected(isSelected)
-                            .isFavorite(isFavorite)
-                            .createdAt(basicQuestionResultDTO.getCreatedAt())
-                            .build();
+                    return QuestionConverter.toBasicQuestionResultDTO(basicQuestionResultDTO, isSelected, isFavorite);
                 })
                 .toList();
 
@@ -186,15 +178,7 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
                         isFavorite = false;
                     }
 
-                    // TODO: converter 분리
-                    return QuestionResponseDTO.BasicQuestionResultDTO.builder()
-                            .id(basicQuestionResultDTO.getId())
-                            .questionType(basicQuestionResultDTO.getQuestionType())
-                            .question(basicQuestionResultDTO.getQuestion())
-                            .isSelected(isSelected)
-                            .isFavorite(isFavorite)
-                            .createdAt(basicQuestionResultDTO.getCreatedAt())
-                            .build();
+                    return QuestionConverter.toBasicQuestionResultDTO(basicQuestionResultDTO, isSelected, isFavorite);
                 })
                 .toList();
 

--- a/src/main/java/com/coredisc/common/converter/QuestionConverter.java
+++ b/src/main/java/com/coredisc/common/converter/QuestionConverter.java
@@ -237,4 +237,15 @@ public class QuestionConverter {
                 .createdAt(officialQuestion.getCreatedAt())
                 .build();
     }
+
+    public static QuestionResponseDTO.BasicQuestionResultDTO toBasicQuestionResultDTO(QuestionResponseDTO.BasicQuestionResultDTO basicQuestion, boolean isSelected, boolean isFavorite) {
+        return QuestionResponseDTO.BasicQuestionResultDTO.builder()
+                .id(basicQuestion.getId())
+                .questionType(basicQuestion.getQuestionType())
+                .question(basicQuestion.getQuestion())
+                .isSelected(isSelected)
+                .isFavorite(isFavorite)
+                .createdAt(basicQuestion.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestionRepository.java
@@ -25,4 +25,6 @@ public interface MemberOfficialQuestionRepository {
 
     List<MemberOfficialQuestion> findByMemberAndCategoryAndCursor(Member member, Category category, Long cursorId, int pageSize);
 
+    boolean existsByMemberIdAndOfficialQuestionIdAndIsFavoriteTrue(Long memberId, Long officialQuestionId);
+
 }

--- a/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestionRepository.java
@@ -27,4 +27,5 @@ public interface OfficialQuestionRepository {
 
     List<Tuple> findTop5PopularQuestionsThisWeek(LocalDate startOfWeek, LocalDate endOfWeek);
 
+    Boolean findIsFavoriteById(Long id);
 }

--- a/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/domain/officialQuestion/OfficialQuestionRepository.java
@@ -27,5 +27,5 @@ public interface OfficialQuestionRepository {
 
     List<Tuple> findTop5PopularQuestionsThisWeek(LocalDate startOfWeek, LocalDate endOfWeek);
 
-    Boolean findIsFavoriteById(Long id);
+    Boolean findIsFavoriteByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/JpaMemberOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/JpaMemberOfficialQuestionRepository.java
@@ -14,4 +14,7 @@ public interface JpaMemberOfficialQuestionRepository extends JpaRepository<Membe
     Optional<MemberOfficialQuestion> findByMemberAndOfficialQuestion(Member member, OfficialQuestion officialQuestion);
 
     long countByOfficialQuestion(OfficialQuestion officialQuestion);
+
+    boolean existsByMemberIdAndOfficialQuestionIdAndIsFavoriteTrue(Long memberId, Long officialQuestionId);
+
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/JpaOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/JpaOfficialQuestionRepository.java
@@ -2,8 +2,6 @@ package com.coredisc.infrastructure.repository.question;
 
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.officialQuestion.OfficialQuestion;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +10,7 @@ public interface JpaOfficialQuestionRepository extends JpaRepository<OfficialQue
 
      Long countOfficialQuestionByMember(Member member);
 
-     @Query("SELECT o.isFavorite FROM OfficialQuestion o WHERE o.id = :id")
-     Boolean findIsFavoriteById(@Param("id") Long id);
+     @Query("SELECT o.isFavorite FROM OfficialQuestion o WHERE o.id = :id AND o.member = :member")
+     Boolean findIsFavoriteByIdAndMember(@Param("id") Long id, @Param("member") Member member);
+
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/JpaOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/JpaOfficialQuestionRepository.java
@@ -5,9 +5,13 @@ import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaOfficialQuestionRepository extends JpaRepository<OfficialQuestion, Long> {
 
      Long countOfficialQuestionByMember(Member member);
 
+     @Query("SELECT o.isFavorite FROM OfficialQuestion o WHERE o.id = :id")
+     Boolean findIsFavoriteById(@Param("id") Long id);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/MemberOfficialQuestionRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/MemberOfficialQuestionRepositoryAdapter.java
@@ -59,5 +59,9 @@ public class MemberOfficialQuestionRepositoryAdapter implements MemberOfficialQu
         return queryMemberOfficialQuestionRepository.findByMemberAndCategoryAndCursor(member, category, cursorId, pageSize);
     }
 
+    @Override
+    public boolean existsByMemberIdAndOfficialQuestionIdAndIsFavoriteTrue(Long memberId, Long officialQuestionId) {
+        return jpaMemberOfficialQuestionRepository.existsByMemberIdAndOfficialQuestionIdAndIsFavoriteTrue(memberId, officialQuestionId);
+    }
 
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/OfficialQuestionRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/OfficialQuestionRepositoryAdapter.java
@@ -1,15 +1,12 @@
 package com.coredisc.infrastructure.repository.question;
 
 import com.coredisc.domain.category.Category;
-import com.coredisc.domain.mapping.questionCategory.QuestionCategory;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.officialQuestion.OfficialQuestionRepository;
 import com.coredisc.infrastructure.repository.question.querydsl.QueryOfficialQuestionRepository;
 import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -57,4 +54,10 @@ public class OfficialQuestionRepositoryAdapter implements OfficialQuestionReposi
     public List<Tuple> findTop5PopularQuestionsThisWeek(LocalDate startOfWeek, LocalDate endOfWeek) {
         return queryOfficialQuestionRepository.findTop5PopularQuestionsThisWeek(startOfWeek, endOfWeek);
     }
+
+    @Override
+    public Boolean findIsFavoriteById(Long id) {
+        return jpaOfficialQuestionRepository.findIsFavoriteById(id);
+    }
+
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/OfficialQuestionRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/OfficialQuestionRepositoryAdapter.java
@@ -56,8 +56,8 @@ public class OfficialQuestionRepositoryAdapter implements OfficialQuestionReposi
     }
 
     @Override
-    public Boolean findIsFavoriteById(Long id) {
-        return jpaOfficialQuestionRepository.findIsFavoriteById(id);
+    public Boolean findIsFavoriteByIdAndMember(Long id, Member member) {
+        return jpaOfficialQuestionRepository.findIsFavoriteByIdAndMember(id, member);
     }
 
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/querydsl/QueryCustomQuestionRepositoryImpl.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/querydsl/QueryCustomQuestionRepositoryImpl.java
@@ -78,6 +78,8 @@ public class QueryCustomQuestionRepositoryImpl implements QueryCustomQuestionRep
                         ((Number) row[0]).longValue(),            // id
                         (String) row[1],                          // questionType
                         (String) row[2],                          // question
+                        false,                                    // isSelected
+                        false,                                    // isFavorite
                         ((Timestamp) row[3]).toLocalDateTime()   // createdAt
                 ))
                 .toList();
@@ -151,6 +153,8 @@ public class QueryCustomQuestionRepositoryImpl implements QueryCustomQuestionRep
                         ((Number) row[0]).longValue(),          // id
                         (String) row[1],                        // questionType
                         (String) row[2],                        // question
+                        false,                                    // isSelected
+                        false,                                    // isFavorite
                         ((Timestamp) row[3]).toLocalDateTime()  // createdAt
                 ))
                 .toList();

--- a/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
@@ -48,6 +48,10 @@ public class QuestionResponseDTO {
 
         private String question;
 
+        private Boolean isSelected;
+
+        private Boolean isFavorite;
+
         private LocalDateTime createdAt;
     }
 


### PR DESCRIPTION
## 💡 작업 내용 요약
프론트 요청에 따라 기본 질문 목록 조회, 기본 질문 검색 목록 조회 시 이미 선택된 질문인지, 즐겨찾기되어 있는지 여부 추가

추후 메서드 분리 고민중입니다. 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #160 

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
