### PR TITLE
feat: 캘린더 API 2개로 분리

### DIFF
--- a/src/main/java/com/coredisc/application/service/calendar/CalendarQueryService.java
+++ b/src/main/java/com/coredisc/application/service/calendar/CalendarQueryService.java
@@ -7,4 +7,5 @@ public interface CalendarQueryService {
 
     CalendarResponseDTO.CalendarDTO getCalendar(int year, int month, Member member);
 
+    Integer getContinuousDays(Member member);
 }

--- a/src/main/java/com/coredisc/application/service/calendar/CalendarQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/calendar/CalendarQueryServiceImpl.java
@@ -43,9 +43,9 @@ public class CalendarQueryServiceImpl implements CalendarQueryService {
     public Integer getContinuousDays(Member member) {
         LocalDate today = LocalDate.now();
         int continuousDays = 0;
-        int batchSize = 100; // 100일 단위로 처리
+        int batchSize = 100; // 100일 단위로 점진적 조회
         
-        // 첫 번째 배치: 오늘부터 100일 전까지
+        // 첫 번째 조회: 오늘부터 100일 전까지
         LocalDate startDate = today.minusDays(batchSize - 1);
         List<Post> posts = postRepository.findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(
             member, 
@@ -53,7 +53,7 @@ public class CalendarQueryServiceImpl implements CalendarQueryService {
             today.atTime(23, 59, 59)
         );
         
-        // 첫 번째 배치에서 연속일수 계산
+        // 첫 번째 조회에서 연속일수 계산
         Set<LocalDate> recordedDates = posts.stream()
             .filter(post -> post.getStatus() == com.coredisc.domain.common.enums.PostStatus.PUBLISHED)
             .map(post -> post.getCreatedAt().toLocalDate())
@@ -66,7 +66,7 @@ public class CalendarQueryServiceImpl implements CalendarQueryService {
             currentDate = currentDate.minusDays(1);
         }
         
-        // 만약 100일을 모두 연속으로 기록했다면, 추가 배치 조회
+        // 만약 100일을 모두 연속으로 기록했다면, 추가 조회
         if (continuousDays == batchSize) {
             // 100일 전부터 200일 전까지 추가 조회
             LocalDate nextStartDate = startDate.minusDays(batchSize);

--- a/src/main/java/com/coredisc/application/service/calendar/CalendarQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/calendar/CalendarQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.coredisc.application.service.calendar;
 
 import com.coredisc.common.converter.CalendarConverter;
 import com.coredisc.domain.member.Member;
+import com.coredisc.domain.post.Post;
 import com.coredisc.domain.post.PostRepository;
 import com.coredisc.presentation.dto.calendar.CalendarPostDTO;
 import com.coredisc.presentation.dto.calendar.CalendarResponseDTO;
@@ -9,8 +10,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,15 +36,64 @@ public class CalendarQueryServiceImpl implements CalendarQueryService {
 
         int totalDays = posts.size();
 
-        int continuesDays = 0;
-        if (year == today.getYear() && month == today.getMonthValue()) {
-            int day = today.getDayOfMonth();
-            while (day > 0 && dayToPostIdMap.containsKey(day)) {
-                continuesDays++;
-                day--;
+        return CalendarConverter.toCalendarDTO(year, month, days, totalDays, LocalDate.from(member.getCreatedAt()));
+    }
+
+    @Override
+    public Integer getContinuousDays(Member member) {
+        LocalDate today = LocalDate.now();
+        int continuousDays = 0;
+        int batchSize = 100; // 100일 단위로 처리
+        
+        // 첫 번째 배치: 오늘부터 100일 전까지
+        LocalDate startDate = today.minusDays(batchSize - 1);
+        List<Post> posts = postRepository.findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(
+            member, 
+            startDate.atStartOfDay(), 
+            today.atTime(23, 59, 59)
+        );
+        
+        // 첫 번째 배치에서 연속일수 계산
+        Set<LocalDate> recordedDates = posts.stream()
+            .filter(post -> post.getStatus() == com.coredisc.domain.common.enums.PostStatus.PUBLISHED)
+            .map(post -> post.getCreatedAt().toLocalDate())
+            .collect(Collectors.toSet());
+        
+        // 오늘부터 이전 날짜로 거슬러 올라가면서 연속 기록 여부 확인
+        LocalDate currentDate = today;
+        while (recordedDates.contains(currentDate)) {
+            continuousDays++;
+            currentDate = currentDate.minusDays(1);
+        }
+        
+        // 만약 100일을 모두 연속으로 기록했다면, 추가 배치 조회
+        if (continuousDays == batchSize) {
+            // 100일 전부터 200일 전까지 추가 조회
+            LocalDate nextStartDate = startDate.minusDays(batchSize);
+            List<Post> additionalPosts = postRepository.findAllByMemberAndCreatedAtBetweenOrderByCreatedAtAsc(
+                member, 
+                nextStartDate.atStartOfDay(), 
+                startDate.minusDays(1).atTime(23, 59, 59)
+            );
+            
+            Set<LocalDate> additionalDates = additionalPosts.stream()
+                .filter(post -> post.getStatus() == com.coredisc.domain.common.enums.PostStatus.PUBLISHED)
+                .map(post -> post.getCreatedAt().toLocalDate())
+                .collect(Collectors.toSet());
+            
+            // 추가 연속일수 계산
+            currentDate = startDate.minusDays(1);
+            while (additionalDates.contains(currentDate)) {
+                continuousDays++;
+                currentDate = currentDate.minusDays(1);
+                
+                // 최대 365일까지 체크
+                if (continuousDays >= 365) {
+                    break;
+                }
             }
         }
-
-        return CalendarConverter.toCalendarDTO(year, month, days, totalDays, continuesDays, LocalDate.from(member.getCreatedAt()));
+        
+        return continuousDays;
     }
 }

--- a/src/main/java/com/coredisc/common/converter/CalendarConverter.java
+++ b/src/main/java/com/coredisc/common/converter/CalendarConverter.java
@@ -39,7 +39,7 @@ public class CalendarConverter {
         return days;
     }
 
-    public static CalendarResponseDTO.CalendarDTO toCalendarDTO(int year, int month, List<CalendarResponseDTO.DayResultDTO> days, int totalDays, int continuesDays, LocalDate signupDate) {
+    public static CalendarResponseDTO.CalendarDTO toCalendarDTO(int year, int month, List<CalendarResponseDTO.DayResultDTO> days, int totalDays, LocalDate signupDate) {
         YearMonth target = YearMonth.of(year, month);
         boolean hasPrevMonth = target.isAfter(YearMonth.from(signupDate));
         boolean hasNextMonth = target.isBefore(YearMonth.now());
@@ -52,7 +52,6 @@ public class CalendarConverter {
                 .startDay(startDay)
                 .days(days)
                 .totalDays(totalDays)
-                .continuesDays(continuesDays)
                 .hasPrevMonth(hasPrevMonth)
                 .hasNextMonth(hasNextMonth)
                 .build();

--- a/src/main/java/com/coredisc/presentation/controller/CalendarController.java
+++ b/src/main/java/com/coredisc/presentation/controller/CalendarController.java
@@ -24,4 +24,9 @@ public class CalendarController implements CalendarControllerDocs {
     public ApiResponse<CalendarResponseDTO.CalendarDTO> getCalendar(@RequestParam int year, @RequestParam int month, @CurrentMember Member member) {
         return ApiResponse.onSuccess(calendarQueryService.getCalendar(year, month, member));
     }
+
+    @GetMapping("/continuous")
+    public ApiResponse<Integer> getContinuousDays(@CurrentMember Member member) {
+        return ApiResponse.onSuccess(calendarQueryService.getContinuousDays(member));
+    }
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/CalendarControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/CalendarControllerDocs.java
@@ -12,10 +12,15 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "Calendar", description = "캘린더 관련 API")
 public interface CalendarControllerDocs {
 
-    @Operation(summary = "월간 답변 기록 캘린더 조회", description = "사용자의 한 달 간의 답변 작성 여부와 연속 답변 일수를 조회합니다.")
+    @Operation(summary = "월간 답변 기록 캘린더 조회", description = "사용자의 한 달 간의 답변 작성 여부를 조회합니다.")
     ApiResponse<CalendarResponseDTO.CalendarDTO> getCalendar(
             @RequestParam("year") int year,
             @RequestParam("month") int month,
+            @Parameter(hidden = true) @CurrentMember Member member
+    );
+
+    @Operation(summary = "연속 답변일수 조회", description = "사용자가 연속으로 기록한 일수를 조회합니다.")
+    ApiResponse<Integer> getContinuousDays(
             @Parameter(hidden = true) @CurrentMember Member member
     );
 }

--- a/src/main/java/com/coredisc/presentation/dto/calendar/CalendarResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/calendar/CalendarResponseDTO.java
@@ -21,7 +21,6 @@ public class CalendarResponseDTO {
         private List<DayResultDTO> days;
 
         private int totalDays;
-        private int continuesDays;
 
         private boolean hasPrevMonth;
         private boolean hasNextMonth;


### PR DESCRIPTION
## 💡 작업 내용 요약
기존에 캘린더 api에서 한 달간의 답변 여부와 연속 답변 일수를 한 번에 가져오던 것을 두 개로 나누었습니다. 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #169 

## 📎 기타 참고사항
연속 답변 일수를 구하는 경우 100일 단위로 처리하여 필요한 만큼만 데이터를 조회하는 방식입니다.
대부분의 사용자는 1번의 DB 쿼리로 처리되고, 100일을 넘어가는 경우에만 추가 조회를 수행합니다. 