### PR TITLE
Refactor: 마이홈 - 아이디/닉네임 수정 후 성공 응답 반환 코드 구분하도록 수정

### DIFF
--- a/src/main/java/com/coredisc/common/apiPayload/ApiResponse.java
+++ b/src/main/java/com/coredisc/common/apiPayload/ApiResponse.java
@@ -32,6 +32,14 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
     }
 
+    public static <T> ApiResponse<T> onSuccess(SuccessStatus status, T result) {
+        return new ApiResponse<>(
+                true,
+                status.getCode(),
+                status.getMessage(),
+                result
+        );
+    }
 
     // 실패한 경우 응답 생성
     public static <T> ApiResponse<T> onFailure(String code, String message, T data){

--- a/src/main/java/com/coredisc/common/apiPayload/status/SuccessStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/SuccessStatus.java
@@ -12,11 +12,11 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus implements BaseCode {
 
     // 일반적인 응답
-    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
 
     // 멤버 관련 응답
-
-    // ~~~ 관련 응답
+    MEMBER_USERNAME_CHANGED(HttpStatus.OK, "MEMBER2001", "아이디 변경 성공 - 재로그인 필요"),
+    MEMBER_PROFILE_UPDATED(HttpStatus.OK, "MEMBER2002", "프로필 변경 성공");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/coredisc/presentation/controller/MemberController.java
+++ b/src/main/java/com/coredisc/presentation/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.coredisc.presentation.controller;
 import com.coredisc.application.service.member.MemberCommandService;
 import com.coredisc.application.service.member.MemberQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
+import com.coredisc.common.apiPayload.status.SuccessStatus;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.controllerdocs.MemberControllerDocs;
 import com.coredisc.presentation.dto.cursor.CursorDTO;
@@ -46,11 +47,16 @@ public class MemberController implements MemberControllerDocs {
 
         // username이 변경되었을 시, 토큰 재발급 요청
         if(isUsernameChanged) {
-            return ApiResponse.onSuccess("아이디가 변경되어 인증이 만료되었습니다. 다시 로그인 해주세요.");
+            return ApiResponse.onSuccess(
+                    SuccessStatus.MEMBER_USERNAME_CHANGED,
+                    "아이디가 변경되어 인증이 만료되었습니다. 다시 로그인 해주세요.");
         }
 
         // nickname만 변경되었을 시
-        return ApiResponse.onSuccess("성공적으로 변경되었습니다.");
+        return ApiResponse.onSuccess(
+                SuccessStatus.MEMBER_PROFILE_UPDATED,
+                "성공적으로 변경되었습니다."
+        );
     }
 
     @Override


### PR DESCRIPTION
## 💡 작업 내용 요약

기존에 두 응답 모두 COMMON200 코드를 반환하던 것을 MEMBER2001, MEMBER2002로 구분하도록 리팩토링하였습니다.

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #178

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
