### PR TITLE
Feat: username 변경 시 디바이스토큰 비활성화 로직 추가

### DIFF
--- a/src/main/java/com/coredisc/application/service/member/MemberCommandService.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberCommandService.java
@@ -11,7 +11,7 @@ public interface MemberCommandService {
     void resetPassword(MemberRequestDTO.ResetPasswordDTO request);
 
     // 마이 홈 - 닉네임, 아이디 변경
-    boolean resetNicknameAndUsernameMyHome(String accessToken, Member member,
+    boolean resetNicknameAndUsernameMyHome(String accessToken, Member member, String deviceToken,
                                            MemberRequestDTO.MyHomeResetNicknameAndUsernameDTO request);
 
     // 계정 탈퇴
@@ -24,7 +24,7 @@ public interface MemberCommandService {
     void resetPasswordMyHome(Member member, MemberRequestDTO.MyHomeResetPasswordDTO request);
 
     // 계정 관리 - 아이디 변경
-    void resetUsernameMyHome(String accessToken, Member member, MemberRequestDTO.MyHomeResetUsernameDTO request);
+    void resetUsernameMyHome(String accessToken, Member member, String deviceToken, MemberRequestDTO.MyHomeResetUsernameDTO request);
 
     // 프로필 사진 변경
     ProfileImgResponseDTO.ProfileImgDTO resetProfileImg(Member member, MultipartFile newProfileImg);

--- a/src/main/java/com/coredisc/application/service/member/MemberCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/member/MemberCommandServiceImpl.java
@@ -52,7 +52,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
-    public boolean resetNicknameAndUsernameMyHome(String accessToken, Member member,
+    public boolean resetNicknameAndUsernameMyHome(String accessToken, Member member, String deviceToken,
                                                   MemberRequestDTO.MyHomeResetNicknameAndUsernameDTO request) {
 
         boolean isUsernameChanged = false;
@@ -78,7 +78,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         // username 변경시 기존 accessToken 블랙리스트 저장
         if (isUsernameChanged) {
-            logoutMember(accessToken);
+            logoutMember(accessToken, deviceToken, request.getNewUsername());
         }
 
         return isUsernameChanged;
@@ -123,7 +123,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
-    public void resetUsernameMyHome(String accessToken, Member member, MemberRequestDTO.MyHomeResetUsernameDTO request) {
+    public void resetUsernameMyHome(String accessToken, Member member, String deviceToken, MemberRequestDTO.MyHomeResetUsernameDTO request) {
 
         if(member.getUsername().equals(request.getNewUsername())) {
             throw new AuthHandler(ErrorStatus.SAME_USERNAME_REQUEST);
@@ -136,7 +136,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         member.setUsername(request.getNewUsername());
         memberRepository.save(member);
 
-        logoutMember(accessToken);
+        logoutMember(accessToken, deviceToken, request.getNewUsername());
     }
 
     @Override
@@ -202,11 +202,14 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
 
-    private void logoutMember(String accessToken) {
+    private void logoutMember(String accessToken, String deviceToken, String newUsername) {
 
         if(accessToken.startsWith("Bear ")) {
             accessToken = accessToken.substring(7);
         }
+        // 디바이스 토큰 비활성화
+        deviceCommandService.deactivateDeviceToken(newUsername, deviceToken);
+
         redisUtil.set(accessToken, "logout");
         redisUtil.expire(accessToken, jwtProvider.getRemainingExpiration(accessToken), TimeUnit.MILLISECONDS);
         // RefreshToken 삭제

--- a/src/main/java/com/coredisc/presentation/controller/MemberController.java
+++ b/src/main/java/com/coredisc/presentation/controller/MemberController.java
@@ -41,9 +41,10 @@ public class MemberController implements MemberControllerDocs {
     @PatchMapping("/profile")
     public ApiResponse<String> resetNicknameAndUsernameMyHome(@RequestHeader("accessToken") String accessToken,
                                                               @CurrentMember Member member,
+                                                              @RequestParam String deviceToken,
                                                               @RequestBody @Valid MemberRequestDTO.MyHomeResetNicknameAndUsernameDTO request) {
 
-        boolean isUsernameChanged = memberCommandService.resetNicknameAndUsernameMyHome(accessToken, member, request);
+        boolean isUsernameChanged = memberCommandService.resetNicknameAndUsernameMyHome(accessToken, member, deviceToken, request);
 
         // username이 변경되었을 시, 토큰 재발급 요청
         if(isUsernameChanged) {
@@ -126,9 +127,10 @@ public class MemberController implements MemberControllerDocs {
     @PatchMapping("/my-home/username")
     public ApiResponse<String> resetUsernameMyHome(@RequestHeader("accessToken") String accessToken,
                                                    @CurrentMember Member member,
+                                                   @RequestParam String deviceToken,
                                                    @RequestBody MemberRequestDTO.MyHomeResetUsernameDTO request) {
 
-        memberCommandService.resetUsernameMyHome(accessToken, member, request);
+        memberCommandService.resetUsernameMyHome(accessToken, member, deviceToken, request);
         return ApiResponse.onSuccess("아이디가 변경되어 인증이 만료되었습니다. 다시 로그인 해주세요.");
     }
 

--- a/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
@@ -27,6 +27,7 @@ public interface MemberControllerDocs {
     @Operation(summary = "마이홈 닉네임, 아이디 변경", description = "닉네임, 아이디 변경 기능입니다.")
     ApiResponse<String> resetNicknameAndUsernameMyHome(@RequestHeader("accessToken") String accessToken,
                                                        @CurrentMember Member member,
+                                                       @RequestParam String deviceToken,
                                                        @RequestBody @Valid MemberRequestDTO.MyHomeResetNicknameAndUsernameDTO request);
 
     @Operation(summary = "계정 탈퇴", description = "계정 탈퇴 기능입니다.")
@@ -68,6 +69,7 @@ public interface MemberControllerDocs {
     @Operation(summary = "마이홈 계정 관리 아이디 변경", description = "계정 관리 아이디 변경 기능입니다.")
     ApiResponse<String> resetUsernameMyHome(@RequestHeader("accessToken") String accessToken,
                                             @CurrentMember Member member,
+                                            @RequestParam String deviceToken,
                                             @RequestBody MemberRequestDTO.MyHomeResetUsernameDTO request);
 
     @Schema(name = "ImageUploadSchema", description = "이미지 파일만 전송하는 multipart 요청")


### PR DESCRIPTION
## 💡 작업 내용 요약
username을 변경 시, 사용자가 로그아웃 처리되고 재로그인을 해야 하기 때문에 디바이스 코드 비활성화 로직을 추가하였습니다.

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [ ] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #199 

## 📎 기타 참고사항
이미 연동이 완료된 API를 수정한 것이라서, 변경 사항을 오늘 또는 15일 이후 중 언제 배포 서버에 반영하는 것이 더 적합한지 프론트엔드 담당자분께 먼저 의견을 확인한 뒤, 최종적으로 머지할 계획입니다.
