### PR TITLE
Refactor: 디스크, 리포트 api 수정

### DIFF
--- a/src/main/java/com/coredisc/application/service/disc/DiscCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/disc/DiscCommandServiceImpl.java
@@ -3,7 +3,6 @@ package com.coredisc.application.service.disc;
 import com.coredisc.common.apiPayload.status.ErrorStatus;
 import com.coredisc.common.converter.DiscConverter;
 import com.coredisc.common.exception.handler.DiscHandler;
-import com.coredisc.common.exception.handler.ProfileImgHandler;
 import com.coredisc.domain.common.enums.DiscCoverColor;
 import com.coredisc.domain.disc.Disc;
 import com.coredisc.domain.disc.DiscRepository;
@@ -62,6 +61,24 @@ public class DiscCommandServiceImpl implements DiscCommandService {
     public Disc updateDiscCoverColor(Long discId, DiscCoverColor coverColor, Member member) {
         Disc disc = discRepository.findByIdAndMember(discId, member)
                 .orElseThrow(() -> new DiscHandler(ErrorStatus.DISC_NOT_FOUND));
+
+        if (disc.getCoverImgUrl() != null){
+            String oldUrl = disc.getCoverImgUrl();
+
+            try {
+                // S3에서 기존 이미지 삭제
+                if (amazonS3Manager.isValidS3Url(oldUrl)) {
+                    String oldFileKey = amazonS3Manager.extractFileKeyFromUrl(oldUrl);
+                    if (oldFileKey != null) {
+                        amazonS3Manager.deleteImageByKey("discCoverImages/" + oldFileKey + ".jpg");
+                    }
+                }
+                disc.setCoverImgUrl(null);
+                
+            } catch (Exception e) {
+                throw new DiscHandler(ErrorStatus.UNKNOWN_ERROR);
+            }
+        }
 
         disc.setCoverColor(coverColor);
         return discRepository.save(disc);

--- a/src/main/java/com/coredisc/application/service/reportStat/ReportRawData.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportRawData.java
@@ -19,6 +19,8 @@ public class ReportRawData {
         private QuestionListRawData questionListRaw;
         private MostSelectedQuestionRawData mostSelectedRaw;
         private HourlyAnswerRawData peakHourRaw;
+        private boolean hasPreviousReport; // 이전 리포트 존재 여부
+        private boolean hasNextReport;     // 다음 리포트 존재 여부
     }
 
     @Getter

--- a/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryService.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface ReportStatQueryService {
 
-    // 웗별 리포트 rawData 조회
+    // 월별 리포트 rawData 조회
     ReportRawData.MonthlyReportRawData getMonthlyReportRawData(int year, int month, Long memberId);
 
     // 기간별 게시글의 daily_ 항목 최다 답변 조회
@@ -15,4 +15,8 @@ public interface ReportStatQueryService {
 
     // 기간별 daily_detail 항목 답변 목록 조회
     List<Post> getDailyDetails(int year, int month, Member member);
+
+    // 이전/다음 리포트 존재 여부 확인
+    boolean hasPreviousReport(int year, int month, Long memberId);
+    boolean hasNextReport(int year, int month, Long memberId);
 }

--- a/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/reportStat/ReportStatQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.coredisc.application.service.reportStat;
 import com.coredisc.common.apiPayload.status.ErrorStatus;
 import com.coredisc.common.exception.handler.ReportStatHandler;
 import com.coredisc.common.util.DateUtil;
+import com.coredisc.domain.disc.DiscRepository;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.post.Post;
 import com.coredisc.domain.post.PostRepository;
@@ -31,6 +32,7 @@ public class ReportStatQueryServiceImpl implements ReportStatQueryService{
     private final MonthlyFixedQuestionStatRepository fixedQuestionRepository;
     private final MonthlySelectionDiaryStatRepository monthlySelectionDiaryStatRepository;
     private final PostRepository postRepository;
+    private final DiscRepository discRepository;
 
     @Override
     public ReportRawData.MonthlyReportRawData getMonthlyReportRawData(int year, int month, Long memberId) {
@@ -38,7 +40,39 @@ public class ReportStatQueryServiceImpl implements ReportStatQueryService{
         ReportRawData.MostSelectedQuestionRawData mostSelectedRaw = getMostSelectedQuestions(year, month, memberId);
         ReportRawData.HourlyAnswerRawData peakHourRaw = getHourlyAnswerCountMap(year, month, memberId);
 
-        return new ReportRawData.MonthlyReportRawData(year, month, questionListRaw, mostSelectedRaw, peakHourRaw);
+        // 이전/다음 리포트 존재 여부 확인
+        boolean hasPreviousReport = hasPreviousReport(year, month, memberId);
+        boolean hasNextReport = hasNextReport(year, month, memberId);
+
+        return new ReportRawData.MonthlyReportRawData(year, month, questionListRaw, mostSelectedRaw, peakHourRaw, hasPreviousReport, hasNextReport);
+    }
+
+    @Override
+    public boolean hasPreviousReport(int year, int month, Long memberId) {
+        // 이전 달 계산
+        int prevYear = year;
+        int prevMonth = month - 1;
+        
+        if (prevMonth < 1) {
+            prevMonth = 12;
+            prevYear = year - 1;
+        }
+        
+        return discRepository.existsByMemberIdAndYearAndMonth(memberId, prevYear, prevMonth);
+    }
+
+    @Override
+    public boolean hasNextReport(int year, int month, Long memberId) {
+        // 다음 달 계산
+        int nextYear = year;
+        int nextMonth = month + 1;
+        
+        if (nextMonth > 12) {
+            nextMonth = 1;
+            nextYear = year + 1;
+        }
+        
+        return discRepository.existsByMemberIdAndYearAndMonth(memberId, nextYear, nextMonth);
     }
 
     @Override

--- a/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
+++ b/src/main/java/com/coredisc/common/converter/ReportStatConverter.java
@@ -189,6 +189,8 @@ public class ReportStatConverter {
                 .isAllOneCount(isAllOneCount)
                 .mostSelectedQuestions(mostSelected)
                 .peakTimeZone(peakTime)
+                .hasPreviousReport(rawData.isHasPreviousReport())
+                .hasNextReport(rawData.isHasNextReport())
                 .build();
     }
 }

--- a/src/main/java/com/coredisc/domain/disc/DiscRepository.java
+++ b/src/main/java/com/coredisc/domain/disc/DiscRepository.java
@@ -14,4 +14,5 @@ public interface DiscRepository {
     List<Disc> findAllByMemberOrderByYearDescMonthDesc(Member member);
     Optional<Disc> findByIdAndMember(Long id, Member member);
     boolean existsByMemberAndYearAndMonth(Member member, int year, int month);
+    boolean existsByMemberIdAndYearAndMonth(Long memberId, int year, int month);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/disc/DiscRepositoryAdaptor.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/disc/DiscRepositoryAdaptor.java
@@ -47,4 +47,9 @@ public class DiscRepositoryAdaptor implements DiscRepository {
     public boolean existsByMemberAndYearAndMonth(Member member, int year, int month) {
         return jpaDiscRepository.existsByMemberAndYearAndMonth(member, year, month);
     }
+
+    @Override
+    public boolean existsByMemberIdAndYearAndMonth(Long memberId, int year, int month) {
+        return jpaDiscRepository.existsByMemberIdAndYearAndMonth(memberId, year, month);
+    }
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/disc/JpaDiscRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/disc/JpaDiscRepository.java
@@ -15,4 +15,5 @@ public interface JpaDiscRepository extends JpaRepository<Disc, Long> {
     List<Disc> findAllByMemberOrderByYearDescMonthDesc(Member member);
     Optional<Disc> findByIdAndMember(Long id, Member member);
     boolean existsByMemberAndYearAndMonth(Member member, int year, int month);
+    boolean existsByMemberIdAndYearAndMonth(Long memberId, int year, int month);
 }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/ReportStatControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/ReportStatControllerDocs.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "Monthly Report", description = "사용자의 월별 리포트 API")
 public interface ReportStatControllerDocs {
 
-    @Operation(summary = "사용자의 월별 리포트 조회", description = "특정 기간 동안 사용자의 활동에 대한 월별 리포트를 조회합니다.")
+    @Operation(summary = "사용자의 월별 리포트 조회", description = "특정 기간 동안 사용자의 활동에 대한 월별 리포트를 조회합니다. 이전/다음 리포트의 존재 여부도 함께 제공됩니다.")
     ApiResponse<ReportStatResponseDTO.MonthlyReportDTO> getMonthlyReport(
             @RequestParam("year") int year,
             @RequestParam("month") int month,

--- a/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/reportStat/ReportStatResponseDTO.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class ReportStatResponseDTO {
 
     @JsonPropertyOrder({
-            "year", "month", "fixedQuestions", "randomQuestions", "allOneCount", "mostSelectedQuestions", "peakTimeZone"
+            "year", "month", "fixedQuestions", "randomQuestions", "allOneCount", "mostSelectedQuestions", "peakTimeZone", "hasPreviousReport", "hasNextReport"
     })
     @Builder
     @Getter
@@ -25,6 +25,8 @@ public class ReportStatResponseDTO {
         private boolean isAllOneCount;
         private List<SelectedQuestionDTO> mostSelectedQuestions;
         private TimeZoneType peakTimeZone;
+        private boolean hasPreviousReport;
+        private boolean hasNextReport;
     }
 
     @Builder


### PR DESCRIPTION
## 💡 작업 내용 요약
- 디스크 이미지를 등록한 뒤에 다시 색깔 커버로 변경할 시에는 먼저 기존 이미지를 삭제하도록 했습니다. 
- 리포트 조회 시에 전후 달의 리포트 존재 여부도 함께 반환합니다. 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #213 

## 📎 기타 참고사항

