### PR TITLE
Feat: 소셜로그인 계정 판별 API 구현

### DIFF
--- a/src/main/java/com/coredisc/common/converter/MemberConverter.java
+++ b/src/main/java/com/coredisc/common/converter/MemberConverter.java
@@ -186,6 +186,13 @@ public class MemberConverter {
                 .build();
     }
 
+    public static MemberResponseDTO.CheckSocialResultDTO toCheckSocialResultDTO(boolean isSocialLogin) {
+
+        return MemberResponseDTO.CheckSocialResultDTO.builder()
+                .isSocialLogin(isSocialLogin)
+                .build();
+    }
+
     // 검색 화면 사용자 검색
     public static MemberResponseDTO.SearchMemberResultDTO toSearchMemberResultDTO(Member member, ProfileImg profileImg) {
         return MemberResponseDTO.SearchMemberResultDTO.builder()

--- a/src/main/java/com/coredisc/presentation/controller/MemberController.java
+++ b/src/main/java/com/coredisc/presentation/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.coredisc.application.service.member.MemberCommandService;
 import com.coredisc.application.service.member.MemberQueryService;
 import com.coredisc.common.apiPayload.ApiResponse;
 import com.coredisc.common.apiPayload.status.SuccessStatus;
+import com.coredisc.common.converter.MemberConverter;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.controllerdocs.MemberControllerDocs;
 import com.coredisc.presentation.dto.cursor.CursorDTO;
@@ -147,6 +148,15 @@ public class MemberController implements MemberControllerDocs {
     public ApiResponse<ProfileImgResponseDTO.ProfileImgDTO> resetToDefaultProfileImg(@CurrentMember Member member) {
         
         return ApiResponse.onSuccess(memberCommandService.resetToDefaultProfileImg(member));
+    }
+
+    @Override
+    @GetMapping("/me/social")
+    public ApiResponse<MemberResponseDTO.CheckSocialResultDTO> checkSocialLogin(@CurrentMember Member member) {
+
+        return ApiResponse.onSuccess(
+                MemberConverter.toCheckSocialResultDTO(member.getIsSocialLogin())
+        );
     }
 
 

--- a/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/MemberControllerDocs.java
@@ -94,6 +94,9 @@ public interface MemberControllerDocs {
     @Operation(summary = "기본 프로필 사진 변경", description = "사용자 기본 프로필 사진으로 변경 기능입니다.")
     ApiResponse<ProfileImgResponseDTO.ProfileImgDTO> resetToDefaultProfileImg(@CurrentMember Member member);
 
+    @Operation(summary = "사용자 소셜로그인 여부 판별", description = "로그인한 사용자가 소셜로그인 사용자인지 핀별합니다.")
+    ApiResponse<MemberResponseDTO.CheckSocialResultDTO> checkSocialLogin(@CurrentMember Member member);
+
     @Operation(summary = "마이홈 내가 작성한 질문 리스트 조회", description = "마이홈 본인 질문 리스트 조회입니다. 커서 기반 페이징입니다.")
     @Parameters({
             @Parameter(name = "categoryId", description = "카테고리id입니다."),

--- a/src/main/java/com/coredisc/presentation/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/member/MemberResponseDTO.java
@@ -87,6 +87,15 @@ public class MemberResponseDTO {
         private String content;
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CheckSocialResultDTO {
+
+        private boolean isSocialLogin;
+    }
+
     // 검색 화면 사용자 검색
     @Getter
     @Builder


### PR DESCRIPTION
## 💡 작업 내용 요약
로그인한 사용자의 계정이 소셜로그인 계정인지 판별하는 API를 구현했습니다.

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #216 

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
