### PR TITLE
Refactor: 모든 질문 저장 가능으로 수정

### DIFF
--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandService.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandService.java
@@ -6,7 +6,6 @@ import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import com.coredisc.domain.personalQuestion.PersonalQuestion;
 import com.coredisc.domain.member.Member;
 import com.coredisc.presentation.dto.question.QuestionRequestDTO;
-import com.coredisc.presentation.dto.question.QuestionResponseDTO;
 
 public interface QuestionCommandService {
 
@@ -30,8 +29,8 @@ public interface QuestionCommandService {
     void deletePersonalQuestion(Member member, Long questionId);
 
     // 타사용자가 작성한 공유 질문 저장
-    MemberOfficialQuestion saveMemberOfficialQuestion(Member member, Long questionId);
+    MemberOfficialQuestion saveMemberOfficialQuestion(Member member, Long questionId, QuestionRequestDTO.SaveMemberOfficialQuestionDTO request);
 
     // 저장헀던 공유 질문을 삭제
-    void deleteMemberOfficialQuestion(Member member, Long questionId);
+    void deleteMemberOfficialQuestion(Member member, Long savedId);
 }

--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
@@ -229,9 +229,9 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
         if (!existPersonalQuestion.getMember().equals(member))
             throw new QuestionHandler(ErrorStatus.UNAUTHORIZED_PERSONAL_QUESTION_ACCESS);
 
-        // 고정 또는 랜덤 질문으로 사용되었으면 삭제 불가
-        if (todayQuestionRepository.existsByPersonalQuestion(existPersonalQuestion)) {
-            throw new QuestionHandler(ErrorStatus.PERSONAL_QUESTION_USED_IN_TODAY_QUESTION);
+        // member_official_question에 추가 여부
+        if (memberOfficialQuestionRepository.existsByMemberIdAndPersonalQuestionId(member.getId(), questionId)) {
+
         }
         
         // 선택된 카테고리 삭제
@@ -246,21 +246,39 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
     @Transactional
     public MemberOfficialQuestion saveMemberOfficialQuestion(Member member, Long questionId, QuestionRequestDTO.SaveMemberOfficialQuestionDTO request) {
 
-        OfficialQuestion selectedOfficialQuestion = officialQuestionRepository.findById(questionId)
-                .orElseThrow(() -> new QuestionHandler(ErrorStatus.OFFICIAL_QUESTION_NOT_FOUND));
+        OfficialQuestion selectedOfficialQuestion = null;
 
         MemberOfficialQuestion memberOfficialQuestion = null;
 
         // 기본 or 공유 질문
         if ((request.getSelectedQuestionType() == QuestionScope.OFFICIAL) || (request.getSelectedQuestionType() == QuestionScope.DEFAULT)) {
+
+            selectedOfficialQuestion = officialQuestionRepository.findById(questionId)
+                    .orElseThrow(() -> new QuestionHandler(ErrorStatus.OFFICIAL_QUESTION_NOT_FOUND));
+
             // 이미 저장 여부
             if (memberOfficialQuestionRepository.findByMemberAndOfficialQuestion(member, selectedOfficialQuestion).isPresent())
                 throw new QuestionHandler(ErrorStatus.ALREADY_SAVED_OFFICIAL_QUESTION);
 
             memberOfficialQuestion = memberOfficialQuestionRepository.save(QuestionConverter.toMemberOfficialQuestion(member, selectedOfficialQuestion, request));
+        } else if (request.getSelectedQuestionType() == QuestionScope.PERSONAL) {   // 개인 질문
+
+            PersonalQuestion selectedPersonalQuestion = personalQuestionRepository.findById(questionId)
+                    .orElseThrow(() -> new QuestionHandler(ErrorStatus.PERSONAL_QUESTION_NOT_FOUND));
+
+            // 이미 저장 여부
+            if (memberOfficialQuestionRepository.findByMemberAndPersonalQuestion(member, selectedPersonalQuestion).isPresent())
+                throw new QuestionHandler(ErrorStatus.ALREADY_SAVED_PERSONAL_QUESTION);
+
+            memberOfficialQuestion = memberOfficialQuestionRepository.save(QuestionConverter.toMemberPersonalQuestion(member, selectedPersonalQuestion, request));
+        } else {
+            throw new QuestionHandler(ErrorStatus.QUESTION_TYPE_NOT_FOUND);
         }
 
+        
+        // 알림 관련
         if ((request.getSelectedQuestionType() == QuestionScope.OFFICIAL)       // 기본 질문 여부 & 작성자 본인 여부 확인
+                && selectedOfficialQuestion != null
                 && selectedOfficialQuestion.isShared()
                 && !(Objects.equals(selectedOfficialQuestion.getMember(), member))) {  
 

--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
@@ -228,7 +228,12 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
         // 작성자 일치 여부
         if (!existPersonalQuestion.getMember().equals(member))
             throw new QuestionHandler(ErrorStatus.UNAUTHORIZED_PERSONAL_QUESTION_ACCESS);
-        
+
+        // 고정 또는 랜덤 질문으로 사용되었으면 삭제 불가
+        if (todayQuestionRepository.existsByPersonalQuestion(existPersonalQuestion)) {
+            throw new QuestionHandler(ErrorStatus.PERSONAL_QUESTION_USED_IN_TODAY_QUESTION);
+        }
+
         // 선택된 카테고리 삭제
         questionCategoryRepository.deleteByPersonalQuestion(existPersonalQuestion);
 

--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
@@ -228,11 +228,6 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
         // 작성자 일치 여부
         if (!existPersonalQuestion.getMember().equals(member))
             throw new QuestionHandler(ErrorStatus.UNAUTHORIZED_PERSONAL_QUESTION_ACCESS);
-
-        // member_official_question에 추가 여부
-        if (memberOfficialQuestionRepository.existsByMemberIdAndPersonalQuestionId(member.getId(), questionId)) {
-
-        }
         
         // 선택된 카테고리 삭제
         questionCategoryRepository.deleteByPersonalQuestion(existPersonalQuestion);

--- a/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionCommandServiceImpl.java
@@ -7,6 +7,7 @@ import com.coredisc.common.converter.QuestionCategoryConverter;
 import com.coredisc.common.converter.QuestionConverter;
 import com.coredisc.common.exception.handler.QuestionHandler;
 import com.coredisc.domain.common.enums.NotificationType;
+import com.coredisc.domain.common.enums.QuestionScope;
 import com.coredisc.domain.common.enums.QuestionType;
 import com.coredisc.domain.device.Device;
 import com.coredisc.domain.device.DeviceRepository;
@@ -36,6 +37,7 @@ import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -242,82 +244,85 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
     // 타사용자가 작성한 공유 질문 저장
     @Override
     @Transactional
-    public MemberOfficialQuestion saveMemberOfficialQuestion(Member member, Long questionId) {
+    public MemberOfficialQuestion saveMemberOfficialQuestion(Member member, Long questionId, QuestionRequestDTO.SaveMemberOfficialQuestionDTO request) {
 
         OfficialQuestion selectedOfficialQuestion = officialQuestionRepository.findById(questionId)
                 .orElseThrow(() -> new QuestionHandler(ErrorStatus.OFFICIAL_QUESTION_NOT_FOUND));
 
-        // 기본 제공 질문인 경우
-        if (!selectedOfficialQuestion.isShared())
-            throw new QuestionHandler(ErrorStatus.CANNOT_SAVE_BASIC_QUESTION);
+        MemberOfficialQuestion memberOfficialQuestion = null;
 
-        // 이미 저장 여부
-        if(memberOfficialQuestionRepository.findByMemberAndOfficialQuestion(member, selectedOfficialQuestion).isPresent())
-            throw new QuestionHandler(ErrorStatus.ALREADY_SAVED_OFFICIAL_QUESTION);
+        // 기본 or 공유 질문
+        if ((request.getSelectedQuestionType() == QuestionScope.OFFICIAL) || (request.getSelectedQuestionType() == QuestionScope.DEFAULT)) {
+            // 이미 저장 여부
+            if (memberOfficialQuestionRepository.findByMemberAndOfficialQuestion(member, selectedOfficialQuestion).isPresent())
+                throw new QuestionHandler(ErrorStatus.ALREADY_SAVED_OFFICIAL_QUESTION);
 
-        // 본인이 작성헀는지 여부
-        if (selectedOfficialQuestion.getMember().equals(member))
-            throw new QuestionHandler(ErrorStatus.CANNOT_SELECT_OWN_OFFICIAL_QUESTION);
-
-        MemberOfficialQuestion memberOfficialQuestion = memberOfficialQuestionRepository.save(QuestionConverter.toMemberOfficialQuestion(member, selectedOfficialQuestion));
-
-        notificationCommandService.createNotification(
-                new NotificationRequestDTO(
-                        NotificationType.SHARED_SAVED, // 알림 타입(공유질문 저장)
-                        member, // 알림 sender
-                        selectedOfficialQuestion.getMember(), // 알림 receiver (공유 질문 작성자)
-                        member.getNickname()+"님이 질문을 저장했어요.",
-                        selectedOfficialQuestion.getId() // 공유질문 id 전달
-                )
-        );
-
-        List<Device> devices = deviceRepository.findByMemberAndIsActiveTrue(selectedOfficialQuestion.getMember());
-
-        // 푸시 알림 내용 설정
-        String title = "CoreDisc";
-        String body = member.getNickname()+"님이 질문을 저장했어요.";
-
-        // 푸시 알림에 보낼 데이터 설정 (알림 타입 및 알림 클릭 -> 이동할 targetId)
-        Map<String, String> data = new HashMap<>();
-        data.put("notificationType", NotificationType.SHARED_SAVED.name());
-        data.put("targetId", String.valueOf(selectedOfficialQuestion.getId()));
-
-        for (Device device : devices) {
-            String token = device.getToken();
-            if (fcmService.isTokenValid(token)) {
-                fcmService.sendNotificationToToken(token, title, body, data);
-                log.info("공유질문 저장 알림 발송됨: memberId={}, token={}", selectedOfficialQuestion.getMember().getId(), token);
-            } else {
-                log.warn("공유질문 저장 알림 발송 안됨: 유효하지 않은 토큰 발견. memberId={}, token={}", selectedOfficialQuestion.getMember().getId(), token);
-            }
+            memberOfficialQuestion = memberOfficialQuestionRepository.save(QuestionConverter.toMemberOfficialQuestion(member, selectedOfficialQuestion, request));
         }
 
-        // 공유질문 저장 100회 단위 저장 알림
-        Long saveCount = memberOfficialQuestionRepository.countByOfficialQuestion(selectedOfficialQuestion);
-        if (saveCount % 100 == 0) {
+        if ((request.getSelectedQuestionType() == QuestionScope.OFFICIAL)       // 기본 질문 여부 & 작성자 본인 여부 확인
+                && selectedOfficialQuestion.isShared()
+                && !(Objects.equals(selectedOfficialQuestion.getMember(), member))) {  
+
             notificationCommandService.createNotification(
                     new NotificationRequestDTO(
-                            NotificationType.SHARED_SAVED,
-                            member,
-                            selectedOfficialQuestion.getMember(),
-                            saveCount + "명의 사용자가 질문을 저장했어요.",
-                            selectedOfficialQuestion.getId()
+                            NotificationType.SHARED_SAVED, // 알림 타입(공유질문 저장)
+                            member, // 알림 sender
+                            selectedOfficialQuestion.getMember(), // 알림 receiver (공유 질문 작성자)
+                            member.getNickname() + "님이 질문을 저장했어요.",
+                            selectedOfficialQuestion.getId() // 공유질문 id 전달
                     )
             );
 
-            // 공유질문 100회 단위 저장 푸시 알림 내용 설정
-            title = "CoreDisc";
-            body = saveCount+"명의 사용자가 질문을 저장했어요.";
+            List<Device> devices = deviceRepository.findByMemberAndIsActiveTrue(selectedOfficialQuestion.getMember());
+
+            // 푸시 알림 내용 설정
+            String title = "CoreDisc";
+            String body = member.getNickname()+"님이 질문을 저장했어요.";
+
+            // 푸시 알림에 보낼 데이터 설정 (알림 타입 및 알림 클릭 -> 이동할 targetId)
+            Map<String, String> data = new HashMap<>();
+            data.put("notificationType", NotificationType.SHARED_SAVED.name());
+            data.put("targetId", String.valueOf(selectedOfficialQuestion.getId()));
 
             for (Device device : devices) {
                 String token = device.getToken();
                 if (fcmService.isTokenValid(token)) {
                     fcmService.sendNotificationToToken(token, title, body, data);
-                    log.info("공유질문 100회 단위 저장 알림 발송됨: memberId={}, token={}", selectedOfficialQuestion.getMember().getId(), token);
+                    log.info("공유질문 저장 알림 발송됨: memberId={}, token={}", selectedOfficialQuestion.getMember().getId(), token);
                 } else {
-                    log.warn("공유질문 100회 단위 저장 알림 발송 안됨: 유효하지 않은 토큰 발견. memberId={}, token={}", selectedOfficialQuestion.getMember().getId(), token);
+                    log.warn("공유질문 저장 알림 발송 안됨: 유효하지 않은 토큰 발견. memberId={}, token={}", selectedOfficialQuestion.getMember().getId(), token);
                 }
             }
+
+            // 공유질문 저장 100회 단위 저장 알림
+            Long saveCount = memberOfficialQuestionRepository.countByOfficialQuestion(selectedOfficialQuestion);
+            if (saveCount % 100 == 0) {
+                notificationCommandService.createNotification(
+                        new NotificationRequestDTO(
+                                NotificationType.SHARED_SAVED,
+                                member,
+                                selectedOfficialQuestion.getMember(),
+                                saveCount + "명의 사용자가 질문을 저장했어요.",
+                                selectedOfficialQuestion.getId()
+                        )
+                );
+
+                // 공유질문 100회 단위 저장 푸시 알림 내용 설정
+                title = "CoreDisc";
+                body = saveCount+"명의 사용자가 질문을 저장했어요.";
+
+                for (Device device : devices) {
+                    String token = device.getToken();
+                    if (fcmService.isTokenValid(token)) {
+                        fcmService.sendNotificationToToken(token, title, body, data);
+                        log.info("공유질문 100회 단위 저장 알림 발송됨: memberId={}, token={}", selectedOfficialQuestion.getMember().getId(), token);
+                    } else {
+                        log.warn("공유질문 100회 단위 저장 알림 발송 안됨: 유효하지 않은 토큰 발견. memberId={}, token={}", selectedOfficialQuestion.getMember().getId(), token);
+                    }
+                }
+            }
+
         }
 
         return memberOfficialQuestion;
@@ -326,12 +331,9 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
     // 저장헀던 공유 질문을 삭제
     @Override
     @Transactional
-    public void deleteMemberOfficialQuestion(Member member, Long questionId) {
+    public void deleteMemberOfficialQuestion(Member member, Long savedId) {
 
-        OfficialQuestion officialQuestion = officialQuestionRepository.findById(questionId)
-                .orElseThrow(() -> new QuestionHandler(ErrorStatus.OFFICIAL_QUESTION_NOT_FOUND));
-
-        MemberOfficialQuestion memberOfficialQuestion = memberOfficialQuestionRepository.findByMemberAndOfficialQuestion(member, officialQuestion)
+        MemberOfficialQuestion memberOfficialQuestion = memberOfficialQuestionRepository.findByMemberAndId(member, savedId)
                 .orElseThrow(() -> new QuestionHandler(ErrorStatus.MEMBER_OFFICIAL_QUESTION_NOT_FOUND));
 
         memberOfficialQuestionRepository.delete(memberOfficialQuestion);

--- a/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.coredisc.common.converter.QuestionConverter;
 import com.coredisc.common.exception.handler.QuestionHandler;
 import com.coredisc.domain.category.Category;
 import com.coredisc.domain.category.CategoryRepository;
+import com.coredisc.domain.common.enums.QuestionScope;
 import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
 import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestionRepository;
 import com.coredisc.domain.member.Member;
@@ -86,6 +87,12 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
                         if (isSaved) {
                             savedStatus = "SAVED";
                         }
+                    } else if ("PERSONAL".equals(basicQuestionResultDTO.getQuestionType())) {
+                        boolean isSaved = memberOfficialQuestionRepository
+                                .existsByMemberIdAndPersonalQuestionId(member.getId(), basicQuestionResultDTO.getId());
+                        if (isSaved) {
+                            savedStatus = "SAVED";
+                        }
                     }
                     
                     return QuestionConverter.toBasicQuestionResultDTO(basicQuestionResultDTO, isSelected, savedStatus);
@@ -138,6 +145,12 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
                     if ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType()) || "DEFAULT".equals(basicQuestionResultDTO.getQuestionType())) {
                         boolean isSaved = memberOfficialQuestionRepository
                                 .existsByMemberIdAndOfficialQuestionId(member.getId(), basicQuestionResultDTO.getId());
+                        if (isSaved) {
+                            savedStatus = "SAVED";
+                        }
+                    } else if ("PERSONAL".equals(basicQuestionResultDTO.getQuestionType())) {
+                        boolean isSaved = memberOfficialQuestionRepository
+                                .existsByMemberIdAndPersonalQuestionId(member.getId(), basicQuestionResultDTO.getId());
                         if (isSaved) {
                             savedStatus = "SAVED";
                         }
@@ -275,12 +288,21 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
 
         List<QuestionResponseDTO.SavedSharedQuestionResultDTO> mySavedSharedQuestionDTOList = mySavedSharedQuestionList.stream()
                 .map(question -> {
-                    long sharedCount = memberOfficialQuestionRepository.countByOfficialQuestion(question.getOfficialQuestion());
-                    // isSelected 체크
-                    boolean isSelected = myTodayQuestionList.stream()
-                            .anyMatch(todayQuestion -> todayQuestion.getOfficialQuestion() != null
-                                    && todayQuestion.getOfficialQuestion().equals(question.getOfficialQuestion()));
-                    return QuestionConverter.toSavedSharedQuestionResultDTO(question, sharedCount, isSelected);
+                    if (question.getQuestionScope() == QuestionScope.PERSONAL) {
+                        long sharedCount = 0;
+                        // isSelected 체크
+                        boolean isSelected = myTodayQuestionList.stream()
+                                .anyMatch(todayQuestion -> todayQuestion.getPersonalQuestion() != null
+                                        && todayQuestion.getPersonalQuestion().equals(question.getPersonalQuestion()));
+                        return QuestionConverter.toSavedSharedPersonalQuestionResultDTO(question, sharedCount, isSelected);
+                    } else {
+                        long sharedCount = memberOfficialQuestionRepository.countByOfficialQuestion(question.getOfficialQuestion());
+                        // isSelected 체크
+                        boolean isSelected = myTodayQuestionList.stream()
+                                .anyMatch(todayQuestion -> todayQuestion.getOfficialQuestion() != null
+                                        && todayQuestion.getOfficialQuestion().equals(question.getOfficialQuestion()));
+                        return QuestionConverter.toSavedSharedOfficialQuestionResultDTO(question, sharedCount, isSelected);
+                    }
                 }).toList();
 
         return new CursorDTO<>(mySavedSharedQuestionDTOList, hasNext);

--- a/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
+++ b/src/main/java/com/coredisc/application/service/question/QuestionQueryServiceImpl.java
@@ -80,21 +80,11 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
                     // 타사용자 공유 질문 저장 여부
                     String savedStatus = "NOT_SAVED";
 
-                    if ("PERSONAL".equals(basicQuestionResultDTO.getQuestionType())) {
-                        savedStatus = "MINE";
-                    } else if ("DEFAULT".equals(basicQuestionResultDTO.getQuestionType())){
-                        savedStatus = "CANNOT_SAVE";
-                    } else if ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType())) {
-                        boolean isMine = officialQuestionRepository.existsByIdAndMember(basicQuestionResultDTO.getId(), member);
-
-                        if (isMine) {
-                            savedStatus = "MINE";
-                        } else {
-                            boolean isSaved = memberOfficialQuestionRepository
-                                    .existsByMemberIdAndOfficialQuestionId(member.getId(), basicQuestionResultDTO.getId());
-                            if (isSaved) {
-                                savedStatus = "SAVED";
-                            }
+                    if ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType()) || "DEFAULT".equals(basicQuestionResultDTO.getQuestionType())) {
+                        boolean isSaved = memberOfficialQuestionRepository
+                                .existsByMemberIdAndOfficialQuestionId(member.getId(), basicQuestionResultDTO.getId());
+                        if (isSaved) {
+                            savedStatus = "SAVED";
                         }
                     }
                     
@@ -145,21 +135,11 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
                     // 타사용자 공유 질문 저장 여부
                     String savedStatus = "NOT_SAVED";
 
-                    if ("PERSONAL".equals(basicQuestionResultDTO.getQuestionType())) {
-                        savedStatus = "MINE";
-                    } else if ("DEFAULT".equals(basicQuestionResultDTO.getQuestionType())){
-                        savedStatus = "CANNOT_SAVE";
-                    } else if ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType())) {
-                        boolean isMine = officialQuestionRepository.existsByIdAndMember(basicQuestionResultDTO.getId(), member);
-
-                        if (isMine) {
-                            savedStatus = "MINE";
-                        } else {
-                            boolean isSaved = memberOfficialQuestionRepository
-                                    .existsByMemberIdAndOfficialQuestionId(member.getId(), basicQuestionResultDTO.getId());
-                            if (isSaved) {
-                                savedStatus = "SAVED";
-                            }
+                    if ("OFFICIAL".equals(basicQuestionResultDTO.getQuestionType()) || "DEFAULT".equals(basicQuestionResultDTO.getQuestionType())) {
+                        boolean isSaved = memberOfficialQuestionRepository
+                                .existsByMemberIdAndOfficialQuestionId(member.getId(), basicQuestionResultDTO.getId());
+                        if (isSaved) {
+                            savedStatus = "SAVED";
                         }
                     }
 

--- a/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/coredisc/common/apiPayload/status/ErrorStatus.java
@@ -106,7 +106,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_FAVORITE_OFFICIAL_QUESTION(HttpStatus.BAD_REQUEST, "QUESTION4013", "이미 즐겨찾기된 질문입니다."),
     ALREADY_NOT_FAVORITE_OFFICIAL_QUESTION(HttpStatus.BAD_REQUEST, "QUESTION4014", "즐겨찾기가 되어있지 않은 질문입니다."),
     CANNOT_FAVORITE_OTHERS_QUESTION(HttpStatus.FORBIDDEN, "QUESTION4015", "자신이 작성한 질문만 즐겨찾기 할 수 있습니다."),
-    CANNOT_SAVE_BASIC_QUESTION(HttpStatus.FORBIDDEN, "QUESTION4016", "기본 질문은 저장할 수 없습니다."),
+    ALREADY_SAVED_PERSONAL_QUESTION(HttpStatus.BAD_REQUEST, "QUESTION4016", "이미 해당 개인 질문을 저장했습니다."),
 
     // Follow 관련 에러
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW4001", "자기 자신은 팔로우할 수 없습니다."),

--- a/src/main/java/com/coredisc/common/converter/QuestionConverter.java
+++ b/src/main/java/com/coredisc/common/converter/QuestionConverter.java
@@ -162,10 +162,11 @@ public class QuestionConverter {
                         .build());
     }
 
-    public static MemberOfficialQuestion toMemberOfficialQuestion(Member member, OfficialQuestion officialQuestion){
+    public static MemberOfficialQuestion toMemberOfficialQuestion(Member member, OfficialQuestion officialQuestion, QuestionRequestDTO.SaveMemberOfficialQuestionDTO request){
 
         return MemberOfficialQuestion.builder()
                 .officialQuestion(officialQuestion)
+                .questionScope(request.getSelectedQuestionType())
                 .member(member)
                 .build();
     }
@@ -189,9 +190,11 @@ public class QuestionConverter {
                 .toList();
 
         return QuestionResponseDTO.SavedSharedQuestionResultDTO.builder()
-                .id(officialQuestion.getId())
+                .savedId(memberOfficialQuestion.getId())
+                .questionId(officialQuestion.getId())
                 .question(officialQuestion.getContents())
                 .categories(categories)
+                .questionType(memberOfficialQuestion.getQuestionScope())
                 .sharedCount(sharedCount)
                 .isSelected(isSelected)
                 .createdAt(officialQuestion.getCreatedAt())

--- a/src/main/java/com/coredisc/common/converter/QuestionConverter.java
+++ b/src/main/java/com/coredisc/common/converter/QuestionConverter.java
@@ -171,6 +171,15 @@ public class QuestionConverter {
                 .build();
     }
 
+    public static MemberOfficialQuestion toMemberPersonalQuestion(Member member, PersonalQuestion personalQuestion, QuestionRequestDTO.SaveMemberOfficialQuestionDTO request){
+
+        return MemberOfficialQuestion.builder()
+                .personalQuestion(personalQuestion)
+                .questionScope(request.getSelectedQuestionType())
+                .member(member)
+                .build();
+    }
+
     public static QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO toSaveMemberOfficialQuestionResultDTO(MemberOfficialQuestion memberOfficialQuestion) {
 
         return QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO.builder()
@@ -179,7 +188,7 @@ public class QuestionConverter {
                 .build();
     }
 
-    public static QuestionResponseDTO.SavedSharedQuestionResultDTO toSavedSharedQuestionResultDTO(MemberOfficialQuestion memberOfficialQuestion, long sharedCount, Boolean isSelected) {
+    public static QuestionResponseDTO.SavedSharedQuestionResultDTO toSavedSharedOfficialQuestionResultDTO(MemberOfficialQuestion memberOfficialQuestion, long sharedCount, Boolean isSelected) {
         OfficialQuestion officialQuestion = memberOfficialQuestion.getOfficialQuestion();
 
         List<CategoryResponseDTO.CategoryInfoDTO> categories = officialQuestion.getQuestionCategoryList().stream()
@@ -198,6 +207,29 @@ public class QuestionConverter {
                 .sharedCount(sharedCount)
                 .isSelected(isSelected)
                 .createdAt(officialQuestion.getCreatedAt())
+                .build();
+    }
+
+
+    public static QuestionResponseDTO.SavedSharedQuestionResultDTO toSavedSharedPersonalQuestionResultDTO(MemberOfficialQuestion memberOfficialQuestion, long sharedCount, Boolean isSelected) {
+        PersonalQuestion personalQuestion = memberOfficialQuestion.getPersonalQuestion();
+
+        List<CategoryResponseDTO.CategoryInfoDTO> categories = personalQuestion.getQuestionCategoryList().stream()
+                .map(qc -> CategoryResponseDTO.CategoryInfoDTO.builder()
+                        .categoryId(qc.getCategory().getId())
+                        .categoryName(qc.getCategory().getName())
+                        .build())
+                .toList();
+
+        return QuestionResponseDTO.SavedSharedQuestionResultDTO.builder()
+                .savedId(memberOfficialQuestion.getId())
+                .questionId(personalQuestion.getId())
+                .question(personalQuestion.getContent())
+                .categories(categories)
+                .questionType(memberOfficialQuestion.getQuestionScope())
+                .sharedCount(sharedCount)
+                .isSelected(isSelected)
+                .createdAt(personalQuestion.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/com/coredisc/domain/common/enums/QuestionScope.java
+++ b/src/main/java/com/coredisc/domain/common/enums/QuestionScope.java
@@ -1,0 +1,5 @@
+package com.coredisc.domain.common.enums;
+
+public enum QuestionScope {
+    DEFAULT, OFFICIAL, PERSONAL
+}

--- a/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestion.java
+++ b/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestion.java
@@ -1,6 +1,7 @@
 package com.coredisc.domain.mapping.memberOfficialQuestion;
 
 import com.coredisc.domain.common.BaseEntity;
+import com.coredisc.domain.common.enums.QuestionScope;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.officialQuestion.OfficialQuestion;
 import jakarta.persistence.*;
@@ -16,6 +17,10 @@ public class MemberOfficialQuestion extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private QuestionScope questionScope;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestion.java
+++ b/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestion.java
@@ -4,6 +4,7 @@ import com.coredisc.domain.common.BaseEntity;
 import com.coredisc.domain.common.enums.QuestionScope;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.officialQuestion.OfficialQuestion;
+import com.coredisc.domain.personalQuestion.PersonalQuestion;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -29,5 +30,9 @@ public class MemberOfficialQuestion extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "official_question_id")
     private OfficialQuestion officialQuestion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "personal_question_id")
+    private PersonalQuestion personalQuestion;
 
 }

--- a/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/domain/mapping/memberOfficialQuestion/MemberOfficialQuestionRepository.java
@@ -3,6 +3,7 @@ package com.coredisc.domain.mapping.memberOfficialQuestion;
 import com.coredisc.domain.category.Category;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.officialQuestion.OfficialQuestion;
+import com.coredisc.domain.personalQuestion.PersonalQuestion;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +18,8 @@ public interface MemberOfficialQuestionRepository {
 
     Optional<MemberOfficialQuestion> findByMemberAndOfficialQuestion(Member member, OfficialQuestion officialQuestion);
 
+    Optional<MemberOfficialQuestion> findByMemberAndPersonalQuestion(Member member, PersonalQuestion personalQuestion);
+
     long countByOfficialQuestion(OfficialQuestion officialQuestion);
 
     List<MemberOfficialQuestion> findAllByMemberAndCursor(Member member, Long cursorId, int pageSize);
@@ -24,5 +27,7 @@ public interface MemberOfficialQuestionRepository {
     List<MemberOfficialQuestion> findByMemberAndCategoryAndCursor(Member member, Category category, Long cursorId, int pageSize);
 
     boolean existsByMemberIdAndOfficialQuestionId(Long memberId, Long officialQuestionId);
+
+    boolean existsByMemberIdAndPersonalQuestionId(Long memberId, Long personalQuestionId);
 
 }

--- a/src/main/java/com/coredisc/domain/personalQuestion/PersonalQuestion.java
+++ b/src/main/java/com/coredisc/domain/personalQuestion/PersonalQuestion.java
@@ -1,5 +1,6 @@
 package com.coredisc.domain.personalQuestion;
 
+import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
 import com.coredisc.domain.todayQuestion.TodayQuestion;
 import com.coredisc.domain.common.BaseEntity;
 import com.coredisc.domain.mapping.questionCategory.QuestionCategory;
@@ -33,6 +34,9 @@ public class PersonalQuestion extends BaseEntity {
 
     @OneToMany(mappedBy = "personalQuestion")
     private List<TodayQuestion> todayQuestionList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "personalQuestion", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberOfficialQuestion> memberOfficialQuestionList = new ArrayList<>();
 
     public void updatePersonalQuestion(String content) {
         this.content = content;

--- a/src/main/java/com/coredisc/infrastructure/repository/question/JpaMemberOfficialQuestionRepository.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/JpaMemberOfficialQuestionRepository.java
@@ -3,6 +3,7 @@ package com.coredisc.infrastructure.repository.question;
 import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.officialQuestion.OfficialQuestion;
+import com.coredisc.domain.personalQuestion.PersonalQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -13,7 +14,11 @@ public interface JpaMemberOfficialQuestionRepository extends JpaRepository<Membe
 
     Optional<MemberOfficialQuestion> findByMemberAndOfficialQuestion(Member member, OfficialQuestion officialQuestion);
 
+    Optional<MemberOfficialQuestion> findByMemberAndPersonalQuestion(Member member, PersonalQuestion personalQuestion);
+
     long countByOfficialQuestion(OfficialQuestion officialQuestion);
 
     boolean existsByMemberIdAndOfficialQuestionId(Long memberId, Long officialQuestionId);
+
+    boolean existsByMemberIdAndPersonalQuestionId(Long memberId, Long personalQuestionId);
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/MemberOfficialQuestionRepositoryAdapter.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/MemberOfficialQuestionRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestion
 import com.coredisc.domain.mapping.memberOfficialQuestion.MemberOfficialQuestionRepository;
 import com.coredisc.domain.member.Member;
 import com.coredisc.domain.officialQuestion.OfficialQuestion;
+import com.coredisc.domain.personalQuestion.PersonalQuestion;
 import com.coredisc.infrastructure.repository.question.querydsl.QueryMemberOfficialQuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -40,6 +41,11 @@ public class MemberOfficialQuestionRepositoryAdapter implements MemberOfficialQu
     }
 
     @Override
+    public Optional<MemberOfficialQuestion> findByMemberAndPersonalQuestion(Member member, PersonalQuestion personalQuestion) {
+        return jpaMemberOfficialQuestionRepository.findByMemberAndPersonalQuestion(member, personalQuestion);
+    }
+
+    @Override
     public long countByOfficialQuestion(OfficialQuestion officialQuestion) {
         return jpaMemberOfficialQuestionRepository.countByOfficialQuestion(officialQuestion);
     }
@@ -57,5 +63,10 @@ public class MemberOfficialQuestionRepositoryAdapter implements MemberOfficialQu
     @Override
     public boolean existsByMemberIdAndOfficialQuestionId(Long memberId, Long officialQuestionId) {
         return jpaMemberOfficialQuestionRepository.existsByMemberIdAndOfficialQuestionId(memberId, officialQuestionId);
+    }
+
+    @Override
+    public boolean existsByMemberIdAndPersonalQuestionId(Long memberId, Long personalQuestionId) {
+        return jpaMemberOfficialQuestionRepository.existsByMemberIdAndPersonalQuestionId(memberId, personalQuestionId);
     }
 }

--- a/src/main/java/com/coredisc/infrastructure/repository/question/querydsl/QueryMemberOfficialQuestionRepositoryImpl.java
+++ b/src/main/java/com/coredisc/infrastructure/repository/question/querydsl/QueryMemberOfficialQuestionRepositoryImpl.java
@@ -25,9 +25,9 @@ public class QueryMemberOfficialQuestionRepositoryImpl implements QueryMemberOff
                 .selectFrom(qMemberOfficialQuestion)
                 .where(
                         qMemberOfficialQuestion.member.eq(member),
-                        cursorId != null ? qMemberOfficialQuestion.officialQuestion.id.lt(cursorId) : null
+                        cursorId != null ? qMemberOfficialQuestion.id.lt(cursorId) : null
                 )
-                .orderBy(qMemberOfficialQuestion.officialQuestion.id.desc())
+                .orderBy(qMemberOfficialQuestion.id.desc())
                 .limit(pageSize + 1)
                 .fetch();
     }
@@ -39,9 +39,9 @@ public class QueryMemberOfficialQuestionRepositoryImpl implements QueryMemberOff
                 .where(
                         qMemberOfficialQuestion.member.eq(member),
                         qMemberOfficialQuestion.officialQuestion.questionCategoryList.any().category.eq(category),
-                        cursorId != null ? qMemberOfficialQuestion.officialQuestion.id.lt(cursorId) : null
+                        cursorId != null ? qMemberOfficialQuestion.id.lt(cursorId) : null
                 )
-                .orderBy(qMemberOfficialQuestion.officialQuestion.id.desc())
+                .orderBy(qMemberOfficialQuestion.id.desc())
                 .limit(pageSize + 1)
                 .fetch();
     }

--- a/src/main/java/com/coredisc/presentation/controller/QuestionController.java
+++ b/src/main/java/com/coredisc/presentation/controller/QuestionController.java
@@ -152,16 +152,16 @@ public class QuestionController implements QuestionControllerDocs {
 
     // 타사용자가 작성한 공유 질문 저장
     @PostMapping("/official/{questionId}")
-    public ApiResponse<QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO> saveMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId) {
+    public ApiResponse<QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO> saveMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId, @Valid @RequestBody QuestionRequestDTO.SaveMemberOfficialQuestionDTO request) {
 
-        return ApiResponse.onSuccess(QuestionConverter.toSaveMemberOfficialQuestionResultDTO(questionCommandService.saveMemberOfficialQuestion(member, questionId)));
+        return ApiResponse.onSuccess(QuestionConverter.toSaveMemberOfficialQuestionResultDTO(questionCommandService.saveMemberOfficialQuestion(member, questionId, request)));
     }
 
     // 저장헀던 공유 질문을 삭제
-    @DeleteMapping("/official/saved/{questionId}")
-    public ApiResponse<String> deleteMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId) {
+    @DeleteMapping("/official/saved/{savedId}")
+    public ApiResponse<String> deleteMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "savedId") Long savedId) {
 
-        questionCommandService.deleteMemberOfficialQuestion(member, questionId);
+        questionCommandService.deleteMemberOfficialQuestion(member, savedId);
 
         return ApiResponse.onSuccess("질문이 삭제되었습니다.");
     }

--- a/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
+++ b/src/main/java/com/coredisc/presentation/controllerdocs/QuestionControllerDocs.java
@@ -108,18 +108,18 @@ public interface QuestionControllerDocs {
     @Parameters({
             @Parameter(name = "questionId", description = "질문ID pathVariable입니다."),
     })
-    ApiResponse<QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO> saveMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId);
+    ApiResponse<QuestionResponseDTO.SaveMemberOfficialQuestionResultDTO> saveMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId, @Valid @RequestBody QuestionRequestDTO.SaveMemberOfficialQuestionDTO request);
 
     @Operation(summary = "저장했던 공유 질문 삭제", description = "타사용자가 발행하여 저장헀던 공유 질문을 삭제하는 기능입니다.")
     @Parameters({
-            @Parameter(name = "questionId", description = "질문ID pathVariable입니다."),
+            @Parameter(name = "savedId", description = "저장 ID pathVariable입니다."),
     })
-    ApiResponse<String> deleteMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "questionId") Long questionId);
+    ApiResponse<String> deleteMemberOfficialQuestion(@CurrentMember Member member, @PathVariable(name = "savedId") Long savedId);
 
     @Operation(summary = "내가 저장한 공유질문 리스트 조회", description = "사용자가 저장한 타사용자의 공유질문 리스트를 조회하는 기능입니다.")
     @Parameters({
             @Parameter(name = "categoryId", description = "카테고리ID입니다. (0 또는 생략 시 전체 조회)"),
-            @Parameter(name = "cursorId", description = "커서 - 마지막 질문 ID, 첫 요청 때는 null"),
+            @Parameter(name = "cursorId", description = "커서 - 저장 목록 ID, 첫 요청 때는 null"),
             @Parameter(name = "size", description = "한 페이지당 조회할 질문 수, 기본값 10"),
     })
     ApiResponse<CursorDTO<QuestionResponseDTO.SavedSharedQuestionResultDTO>> getSavedSharedQuestionList(

--- a/src/main/java/com/coredisc/presentation/dto/question/QuestionRequestDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/question/QuestionRequestDTO.java
@@ -1,5 +1,6 @@
 package com.coredisc.presentation.dto.question;
 
+import com.coredisc.domain.common.enums.QuestionScope;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
@@ -63,5 +64,13 @@ public class QuestionRequestDTO {
         @NotNull
         @Schema(description = "questionId", example = "1")
         Long questionId;
+    }
+
+    @Getter
+    public static class SaveMemberOfficialQuestionDTO {
+
+        @NotNull
+        @Schema(description = "질문 타입 (DEFAULT / OFFICIAL / PERSONAL)", example = "PERSONAL")
+        QuestionScope selectedQuestionType;
     }
 }

--- a/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
+++ b/src/main/java/com/coredisc/presentation/dto/question/QuestionResponseDTO.java
@@ -1,5 +1,6 @@
 package com.coredisc.presentation.dto.question;
 
+import com.coredisc.domain.common.enums.QuestionScope;
 import com.coredisc.domain.common.enums.QuestionType;
 import com.coredisc.presentation.dto.category.CategoryResponseDTO;
 import com.coredisc.presentation.dto.cursor.CursorDTO;
@@ -154,9 +155,13 @@ public class QuestionResponseDTO {
     @Builder
     public static class SavedSharedQuestionResultDTO {
 
-        private Long id;
+        private Long savedId;
+
+        private Long questionId;
 
         private List<CategoryResponseDTO.CategoryInfoDTO> categories;
+
+        private QuestionScope questionType;
 
         private String question;
 


### PR DESCRIPTION
## 💡 작업 내용 요약

- 저장 가능 질문 범위 확대
- 기본 질문도 저장 가능
- 본인이 발행한 공유 질문 저장 가능
- 본인이 작성한 개인 질문 저장 가능
- 저장한 질문 목록 조회 시 저장 id 추가, 커서를 저장 id 기반으로 수정, 질문 타입 추가
- 저장한 질문 삭제를 저장 id 기준으로 변경
- 개인 질문 삭제 시 저장 목록에서 제외 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작을 확인했는가?
- [x] 코드 리뷰 포인트가 있는가?

## 🔗 관련 이슈
Closes #225

## 📎 기타 참고사항
추가로 설명할 내용이 있다면 작성해주세요.
